### PR TITLE
Hey all, I have another addition: reading saml:Attribute tags

### DIFF
--- a/onelogin/saml/Response.py
+++ b/onelogin/saml/Response.py
@@ -84,6 +84,13 @@ class Response(object):
         doc="The value requested in the name_identifier_format, e.g., the user's email address",
         )
 
+    def get_assertion_attribute_value(self,attribute_name):
+        """
+        Get the value of an AssertionAttribute, located in an Assertion/AttributeStatement/Attribute[@Name=attribute_name/AttributeValue tag
+        """
+        result = self._document.xpath('/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="%s"]/saml:AttributeValue'%attribute_name,namespaces=namespaces)
+        return [n.text.strip() for n in result]
+
     def is_valid(
         self,
         _clock=None,


### PR DESCRIPTION
I made another addition to python-saml. It involves reading saml:Attribute tags from the saml:Assertion tag. These saml:Attributes can contain additional data stored in the Assertion.
An example message is this, where I want the saml.Response to fetch the value for the saml:Attribute named "datasessionid".

``` python
>>> response.get_assertion_attribute_value('datasessionid')
```

from the the following message:

``` xml
    <?xml version="1.0"?>
     <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
        <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="634660173980483268">
            <saml:Conditions NotOnOrAfter="2012-02-28T08:22:38Z"/>
            <saml:AttributeStatement>
                <saml:Attribute Name="datasessionid">
                    <saml:AttributeValue>8</saml:AttributeValue>
                </saml:Attribute>
                <saml:Attribute Name="url">
                    <saml:AttributeValue/>
                </saml:Attribute>
            </saml:AttributeStatement>
        </saml:Assertion>
    </samlp:Response>
```
