### PR TITLE
Push to fix import and typo

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,7 +9,7 @@ from StringIO import StringIO
 from BaseHTTPServer import BaseHTTPRequestHandler
 from BaseHTTPServer import HTTPServer
 
-from onelogin.saml import AuthnRequest, Response
+from onelogin.saml import AuthRequest, Response
 
 __version__ = '0.1'
 

--- a/onelogin/saml/__init__.py
+++ b/onelogin/saml/__init__.py
@@ -4,3 +4,5 @@ from Response import (
     ResponseNameIDError,
     ResponseConditionError,
     )
+import AuthRequest
+import SignatureVerifier


### PR DESCRIPTION
https://github.com/onelogin/python-saml/blob/master/onelogin/saml/__init__.py

``` python
from Response import (
    Response,
    ResponseValidationError,
    ResponseNameIDError,
    ResponseConditionError,
    )
```

should be

``` python
from Response import (
    Response,
    ResponseValidationError,
    ResponseNameIDError,
    ResponseConditionError,
    )

import AuthRequest
import SignatureVerifier
```

here is the python dir

``` bash
(venv)cgraham@cgraham-m01:~/data/github/python-saml$ python
Python 2.7.3 (default, Oct 29 2012, 09:13:15) 
[GCC 4.2.1 Compatible Apple Clang 4.1 ((tags/Apple/clang-421.11.65))] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from onelogin.saml import AuthnRequest, Response
ImportError: cannot import name AuthRequest
>>> import onelogin
>>> dir(onelogin)
['__builtins__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', 'saml']
>>> from onelogin import saml
>>> dir(saml)
['Response', 'ResponseConditionError', 'ResponseNameIDError', 'ResponseValidationError', 'SignatureVerifier', '__builtins__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__']
```
