### PR TITLE
Use a DTD to verify the layout of the XML response

### DIFF
--- a/onelogin/saml/Response.py
+++ b/onelogin/saml/Response.py
@@ -58,7 +58,7 @@ class Response(object):
         self._signature = signature
 
     def _parse_datetime(self, dt):
-        return datetime.strptime(dt, '%Y-%m-%dT%H:%M:%SZ')
+        return datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S.%fZ')
 
     def _get_name_id(self):
         result = self._document.xpath(

--- a/onelogin/saml/SignatureVerifier.py
+++ b/onelogin/saml/SignatureVerifier.py
@@ -116,13 +116,14 @@ def verify(
                 cmds = [
                     xmlsec_bin,
                     '--verify',
+                    '--dtd-file',
+                    'saml.dtd',
                     '--pubkey-cert-pem',
                     cert_filename,
                     '--id-attr:ID',
                     'urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
                     xml_filename,
                     ]
-
                 proc = _subprocess.Popen(
                     cmds,
                     stderr=_subprocess.PIPE,


### PR DESCRIPTION
Date format was incompatible with ours because we have millisecond precision. Added fix.

XMLSec could not properly parse the XML file and caused various errors. The workaround is to use a DTD file.
See: http://www.aleksey.com/xmlsec/faq.html (Section 3.2)
