### PR TITLE
properly handle timezones and a few small unittest fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Python Requirements
 - python2.6
 - python2.6-dev
 - lxml 2.3 or greater
+- python-dateutil<2.0 (>2.0 for python 3.x)
 
 Test Requirements
 =================

--- a/onelogin/saml/Response.py
+++ b/onelogin/saml/Response.py
@@ -2,6 +2,8 @@ import base64
 
 from lxml import etree
 from datetime import datetime, timedelta
+import dateutil.tz
+import dateutil.parser
 
 from onelogin.saml import SignatureVerifier
 
@@ -58,7 +60,7 @@ class Response(object):
         self._signature = signature
 
     def _parse_datetime(self, dt):
-        return datetime.strptime(dt, '%Y-%m-%dT%H:%M:%SZ')
+        return dateutil.parser.parse(dt)
 
     def _get_name_id(self):
         result = self._document.xpath(
@@ -101,7 +103,7 @@ class Response(object):
         Return True if valid, otherwise False.
         """
         if _clock is None:
-            _clock = datetime.utcnow
+            _clock = lambda :datetime.now(dateutil.tz.tzutc())
         if _verifier is None:
             _verifier = SignatureVerifier.verify
 

--- a/onelogin/saml/test/TestAuthRequest.py
+++ b/onelogin/saml/test/TestAuthRequest.py
@@ -3,9 +3,9 @@ import fudge
 from datetime import datetime
 from nose.tools import eq_ as eq
 
-from onelogin.saml import AuthnRequest
+from onelogin.saml import AuthRequest
 
-class TestAuthnRequest(object):
+class TestAuthRequest(object):
     def setUp(self):
         fudge.clear_expectations()
 
@@ -42,7 +42,7 @@ class TestAuthnRequest(object):
             )
         fake_urlencode.returns('foo_urlencoded')
 
-        req = AuthnRequest.create(
+        req = AuthRequest.create(
             _clock=fake_clock,
             _uuid=fake_uuid_func,
             _zlib=fake_zlib,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ class ExampleCommand(_install.install):
 
 install_requires = [
         'lxml>=2.3',
+        'python-dateutil<2.0',
         ]
 tests_require = [
         'fudge >=0.9.5',
@@ -42,7 +43,7 @@ tests_require = [
 
 setup(
     name='onelogin.saml',
-    version='0.0.1',
+    version='0.0.2',
     description="Python client library for SAML Version 2.0",
     packages = find_packages(),
     namespace_packages = ['onelogin'],


### PR DESCRIPTION
Hi all,

I see in onelogin.saml.Response strptime being used on line 61. This causes a problem when receiving a datetime string with a timezone specification. It is possible to use dateutil.parser.parse instead, which parses a datetime string better, and returns a datetime.datetime object with the tzinfo attribute set. 
It does require python-dateutil which can be installed using easy_install. 
I added this functionality, including unittests, and modification of setup.py and README.rst.

Aside from this, I fixed two unittests which failed before these changes already (AuthnRequest object was aparently renamed, but unittests were not, and my previous fix on NotBefore not being required was not reflected in unittests).

Cheers,

Dolf Andringa.
