### PR TITLE
Fix AuthRequest when base URL contains query params.

### DIFF
--- a/onelogin/saml/AuthRequest.py
+++ b/onelogin/saml/AuthRequest.py
@@ -105,7 +105,13 @@ def create(_clock=None, _uuid=None, _zlib=None, _base64=None,
         [('SAMLRequest', encoded_request)],
     )
 
-    return '{url}?{query}'.format(
+    if '?' in idp_sso_target_url:
+        separator = '&'
+    else:
+        separator = '?'
+
+    return '{url}{sep}{query}'.format(
         url=idp_sso_target_url,
+        sep=separator,
         query=urlencoded_request,
     )


### PR DESCRIPTION
If the SSO target URL already contains a query part, the SAMLRequest
parameter should be separated from the URL with '&' instead of '?'.
