### PR TITLE
Don't use default global XML parser to parse response.

### DIFF
--- a/onelogin/saml/Response.py
+++ b/onelogin/saml/Response.py
@@ -52,7 +52,7 @@ class Response(object):
             _etree = etree
 
         decoded_response = _base64.b64decode(response)
-        self._document = _etree.fromstring(decoded_response)
+        self._document = _etree.fromstring(decoded_response, parser=_etree.XMLParser())
         self._signature = signature
 
     def _parse_datetime(self, dt):

--- a/onelogin/saml/test/TestResponse.py
+++ b/onelogin/saml/test/TestResponse.py
@@ -81,8 +81,12 @@ class TestResponse(object):
 
         fake_etree = fudge.Fake('etree')
         fake_etree.remember_order()
+        xmlparser = fake_etree.expects('XMLParser')
+        xmlparser.with_arg_count(0)
+        fake_xmlparser = fudge.Fake('etree.XMLParser')
+        xmlparser.returns(fake_xmlparser)
         from_string = fake_etree.expects('fromstring')
-        from_string.with_args('foo decoded response')
+        from_string.with_args('foo decoded response', parser=fake_xmlparser)
         from_string.returns('foo document')
 
         res = Response(


### PR DESCRIPTION
If the default global parser is set to remove blank text nodes (remove_blank_text=True),
signature validation will fail because the whitespace inside the ds:Signature element matters.

I ran into this problem when trying to use python-saml inside a larger application that set the default XMLParser to a custom parser that wasn't preserving whitespace.

Instead of using the default parser, construct a new XMLParser to parse the response.
