### PR TITLE
syntax typo in demo-flask/saml/settings.json

### DIFF
--- a/demo-flask/saml/settings.json
+++ b/demo-flask/saml/settings.json
@@ -27,4 +27,4 @@
         },
         "x509cert": "<onelogin_connector_cert>"
     }
-}}
+}


### PR DESCRIPTION
Removing extra } in demo-flask/saml/settings.json
