### PR TITLE
Single Log Out Fix

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -272,7 +272,7 @@ class OneLogin_Saml2_Auth(object):
             parameters['Signature'] = self.build_request_signature(saml_request, parameters['RelayState'])
         return self.redirect_to(self.get_sso_url(), parameters)
 
-    def logout(self, return_to=None):
+    def logout(self, return_to=None, name_id=None):
         """
         Initiates the SLO process.
 
@@ -288,7 +288,7 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SAML_SINGLE_LOGOUT_NOT_SUPPORTED
             )
 
-        logout_request = OneLogin_Saml2_Logout_Request(self.__settings)
+        logout_request = OneLogin_Saml2_Logout_Request(self.__settings, name_id_value=name_id)
 
         saml_request = logout_request.get_request()
 

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -272,7 +272,7 @@ class OneLogin_Saml2_Auth(object):
             parameters['Signature'] = self.build_request_signature(saml_request, parameters['RelayState'])
         return self.redirect_to(self.get_sso_url(), parameters)
 
-    def logout(self, return_to=None, name_id=None):
+    def logout(self, return_to=None, name_id=None, session_index=None):
         """
         Initiates the SLO process.
 
@@ -288,7 +288,8 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SAML_SINGLE_LOGOUT_NOT_SUPPORTED
             )
 
-        logout_request = OneLogin_Saml2_Logout_Request(self.__settings, name_id_value=name_id)
+        logout_request = OneLogin_Saml2_Logout_Request(self.__settings, name_id=name_id, 
+                                                       session_index=session_index)
 
         saml_request = logout_request.get_request()
 

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -29,7 +29,7 @@ class OneLogin_Saml2_Logout_Request(object):
 
     """
 
-    def __init__(self, settings, request=None, name_id_value=None):
+    def __init__(self, settings, request=None, name_id=None, session_index=None):
         """
         Constructs the Logout Request object.
 
@@ -45,8 +45,10 @@ class OneLogin_Saml2_Logout_Request(object):
             security = self.__settings.get_security_data()
 
             uid = OneLogin_Saml2_Utils.generate_unique_id()
-            if not name_id_value:
+            if not name_id:
                 name_id_value = OneLogin_Saml2_Utils.generate_unique_id()
+            else:
+                name_id_value = name_id
             issue_instant = OneLogin_Saml2_Utils.parse_time_to_SAML(OneLogin_Saml2_Utils.now())
 
             cert = None
@@ -69,6 +71,7 @@ class OneLogin_Saml2_Logout_Request(object):
         Destination="%(single_logout_url)s">
         <saml:Issuer>%(entity_id)s</saml:Issuer>
         %(name_id)s
+        %(session_index)s
     </samlp:LogoutRequest>""" % \
                 {
                     'id': uid,
@@ -76,6 +79,7 @@ class OneLogin_Saml2_Logout_Request(object):
                     'single_logout_url': idp_data['singleLogoutService']['url'],
                     'entity_id': sp_data['entityId'],
                     'name_id': name_id,
+                    'session_index' : self._generate_session_index(session_index)
                 }
         else:
             decoded = b64decode(request)
@@ -95,6 +99,13 @@ class OneLogin_Saml2_Logout_Request(object):
         :rtype: str object
         """
         return OneLogin_Saml2_Utils.deflate_and_base64_encode(self.__logout_request)
+    
+    
+    def _generate_session_index(self,id):
+        if id:
+            return "<samlp:SessionIndex>%s</samlp:SessionIndex>" % id 
+        else:
+            ""
 
     @staticmethod
     def get_id(request):

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -29,7 +29,7 @@ class OneLogin_Saml2_Logout_Request(object):
 
     """
 
-    def __init__(self, settings, request=None):
+    def __init__(self, settings, request=None, name_id_value=None):
         """
         Constructs the Logout Request object.
 
@@ -45,7 +45,8 @@ class OneLogin_Saml2_Logout_Request(object):
             security = self.__settings.get_security_data()
 
             uid = OneLogin_Saml2_Utils.generate_unique_id()
-            name_id_value = OneLogin_Saml2_Utils.generate_unique_id()
+            if not name_id_value:
+                name_id_value = OneLogin_Saml2_Utils.generate_unique_id()
             issue_instant = OneLogin_Saml2_Utils.parse_time_to_SAML(OneLogin_Saml2_Utils.now())
 
             cert = None

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -105,7 +105,7 @@ class OneLogin_Saml2_Logout_Request(object):
         if id:
             return "<samlp:SessionIndex>%s</samlp:SessionIndex>" % id 
         else:
-            ""
+            return ""
 
     @staticmethod
     def get_id(request):


### PR DESCRIPTION
I had problem with IdP  from Oracle -  SSO worked fine, but SLO had two problems with LogoutRequest:
* nameID in request  was different  from nameID authenticated  with IdP  (actually nameID in Logout request is generated randomly).
* SessionIndex was missing in LogoutRequest 

I added two parameters to logout method,   so current name_id and session_index can be passed to LogoutRequest.

As per [SAML v2 profile](http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf])
4.4.4.1 <LogoutRequest> Usage
The <Issuer> element MUST be present and MUST contain the unique identifier of the requesting entity;
the Format attribute MUST be omitted or have a value of urn:oasis:names:tc:SAML:2.0:nameidformat:
entity.
The requester MUST authenticate itself to the responder and ensure message integrity, either by signing
the message or using a binding-specific mechanism.
The principal MUST be identified in the request using an identifier that strongly matches the identifier in
the authentication assertion the requester issued or received regarding the session being terminated, per
the matching rules defined in Section 3.3.4 of [SAMLCore].
If the requester is a session participant, it MUST include at least one <SessionIndex> element in the
request. If the requester is a session authority (or acting on its behalf), then it MAY omit any such
elements to indicate the termination of all of the principal's applicable sessions.

It looks like these changes are necessary to match standard requirements.