### PR TITLE
Implement demo-bottle

### DIFF
--- a/demo-bottle/index.py
+++ b/demo-bottle/index.py
@@ -1,0 +1,177 @@
+import os
+
+from bottle import Bottle, run, redirect, request, response, ServerAdapter, jinja2_view
+from beaker.middleware import SessionMiddleware
+
+from urlparse import urlparse
+
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
+
+
+app = Bottle(__name__)
+app.config['SECRET_KEY'] = 'onelogindemopytoolkit'
+app.config['SAML_PATH'] = os.path.join(os.path.dirname(__file__), 'saml')
+
+
+session_opts = {
+    'session.type': 'file',
+    'session.cookie_expires': 300,
+    'session.data_dir': './.data',
+    'session.auto': True
+}
+
+
+def init_saml_auth(req):
+    auth = OneLogin_Saml2_Auth(req, custom_base_path=app.config['SAML_PATH'])
+    return auth
+
+
+def prepare_bottle_request(req):
+    url_data = urlparse(req.url)
+    return {
+        'http_host': req.get_header('host'),
+        'server_port': url_data.port,
+        'script_name': req.fullpath,
+        'get_data': req.query,
+        'post_data': req.forms,
+        'https': 'on' if req.urlparts.scheme == 'https' else 'off'
+    }
+
+
+@app.route('/acs', method='POST')
+@jinja2_view('index.html', template_lookup=['templates'])
+def index():
+    req = prepare_bottle_request(request)
+    auth = init_saml_auth(req)
+    paint_logout = False
+    attributes = False
+
+    session = request.environ['beaker.session']
+
+    auth.process_response()
+    errors = auth.get_errors()
+    not_auth_warn = not auth.is_authenticated()
+    if len(errors) == 0:
+        session['samlUserdata'] = auth.get_attributes()
+        session['samlNameId'] = auth.get_nameid()
+        session['samlSessionIndex'] = auth.get_session_index()
+        self_url = OneLogin_Saml2_Utils.get_self_url(req)
+        if 'RelayState' in request.forms and self_url != request.forms['RelayState']:
+            return redirect(request.forms['RelayState'])
+
+    if 'samlUserdata' in session:
+        paint_logout = True
+        if len(session['samlUserdata']) > 0:
+            attributes = session['samlUserdata'].items()
+
+    return {
+        'errors':errors,
+        'not_auth_warn':not_auth_warn,
+        'attributes':attributes,
+        'paint_logout':paint_logout
+    }
+
+
+@app.route('/', method='GET')
+@jinja2_view('index.html', template_lookup=['templates'])
+def index():
+    req = prepare_bottle_request(request)
+    auth = init_saml_auth(req)
+    errors = []
+    not_auth_warn = False
+    success_slo = False
+    attributes = False
+    paint_logout = False
+
+    session = request.environ['beaker.session']
+
+    if 'sso' in request.query:
+        return_to = '{0}://{1}/'.format(request.urlparts.scheme, request.get_header('host'))
+        return redirect(auth.login(return_to))
+    elif 'sso2' in request.query:
+        return_to = '{0}://{1}/attrs/'.format(request.urlparts.scheme, request.get_header('host'))
+        return redirect(auth.login(return_to))
+    elif 'slo' in request.query:
+        name_id = None
+        session_index = None
+        if 'samlNameId' in session:
+            name_id = session['samlNameId']
+        if 'samlSessionIndex' in session:
+            session_index = session['samlSessionIndex']
+
+        return redirect(auth.logout(name_id=name_id, session_index=session_index))
+    elif 'sls' in request.query:
+        dscb = lambda: session.clear()
+        url = auth.process_slo(delete_session_cb=dscb)
+        errors = auth.get_errors()
+        if len(errors) == 0:
+            if url is not None:
+                return redirect(url)
+            else:
+                success_slo = True
+
+    if 'samlUserdata' in session:
+        paint_logout = True
+        if len(session['samlUserdata']) > 0:
+            attributes = session['samlUserdata'].items()
+
+    return {
+        'errors':errors,
+        'not_auth_warn':not_auth_warn,
+        'success_slo':success_slo,
+        'attributes':attributes,
+        'paint_logout':paint_logout
+    }
+
+
+@app.route('/attrs/')
+@jinja2_view('attrs.html', template_lookup=['templates'])
+def attrs():
+    paint_logout = False
+    attributes = False
+    session = request.environ['beaker.session']
+
+    if 'samlUserdata' in session:
+        paint_logout = True
+        if len(session['samlUserdata']) > 0:
+            attributes = session['samlUserdata'].items()
+
+    return {'paint_logout':paint_logout,
+            'attributes':attributes}
+
+
+@app.route('/metadata/')
+def metadata():
+    req = prepare_bottle_request(request)
+    auth = init_saml_auth(req)
+    settings = auth.get_settings()
+    metadata = settings.get_sp_metadata()
+    errors = settings.validate_metadata(metadata)
+
+    if len(errors) == 0:
+        response.status = 200
+        response.set_header('Content-Type', 'text/xml')
+        return metadata
+    else:
+        response.status = 500
+        return ','.join(errors)
+
+
+class SSLPasteServer(ServerAdapter):
+    def run(self, handler):
+        from paste import httpserver
+
+        server = httpserver.serve(handler, '0.0.0.0', '8000', ssl_pem='local.pem', start_loop=False)
+        try:
+            server.serve_forever()
+        finally:
+            server.server_close()
+
+
+if __name__ == "__main__":
+    # To run HTTPS
+    #run(SessionMiddleware(app, config=session_opts), host='0.0.0.0', port=8000, debug=True, reloader=True, server=SSLPasteServer)
+
+    # To run HTTP
+    run(SessionMiddleware(app, config=session_opts), host='0.0.0.0', port=8000, debug=True, reloader=True, server='paste')

--- a/demo-bottle/requirements.txt
+++ b/demo-bottle/requirements.txt
@@ -1,0 +1,4 @@
+bottle==0.12.8
+beaker==1.6.4
+paste==1.7.5.1
+jinja2==2.7.3

--- a/demo-bottle/saml/advanced_settings.json
+++ b/demo-bottle/saml/advanced_settings.json
@@ -1,0 +1,29 @@
+{
+    "security": {
+        "nameIdEncrypted": false,
+        "authnRequestsSigned": false,
+        "logoutRequestSigned": false,
+        "logoutResponseSigned": false,
+        "signMetadata": false,
+        "wantMessagesSigned": false,
+        "wantAssertionsSigned": false,
+        "wantNameIdEncrypted": false
+    },
+    "contactPerson": {
+        "technical": {
+            "givenName": "technical_name",
+            "emailAddress": "technical@example.com"
+        },
+        "support": {
+            "givenName": "support_name",
+            "emailAddress": "support@example.com"
+        }
+    },
+    "organization": {
+        "en-US": {
+            "name": "sp_test",
+            "displayname": "SP test",
+            "url": "http://sp.example.com"
+        }
+    }
+}

--- a/demo-bottle/saml/certs/README
+++ b/demo-bottle/saml/certs/README
@@ -1,0 +1,11 @@
+Take care of this folder that could contain private key. Be sure that this folder never is published.
+
+Onelogin Python Toolkit expects that certs for the SP could be stored in this folder as:
+
+ * sp.key   Private Key
+ * sp.cert  Public cert
+
+Also you can use other cert to sign the metadata of the SP using the:
+
+ * metadata.key
+ * metadata.cert

--- a/demo-bottle/saml/settings.json
+++ b/demo-bottle/saml/settings.json
@@ -1,0 +1,30 @@
+{
+    "strict": true,
+    "debug": true,
+    "sp": {
+        "entityId": "https://<sp_domain>/metadata/",
+        "assertionConsumerService": {
+            "url": "https://<sp_domain>/?acs",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        },
+        "singleLogoutService": {
+            "url": "https://<sp_domain>/?sls",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "x509cert": "",
+        "privateKey": ""
+    },
+    "idp": {
+        "entityId": "https://app.onelogin.com/saml/metadata/<onelogin_connector_id>",
+        "singleSignOnService": {
+            "url": "https://app.onelogin.com/trust/saml2/http-post/sso/<onelogin_connector_id>",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "singleLogoutService": {
+            "url": "https://app.onelogin.com/trust/saml2/http-redirect/slo/<onelogin_connector_id>",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "x509cert": "<onelogin_connector_cert>"
+    }
+}

--- a/demo-bottle/templates/attrs.html
+++ b/demo-bottle/templates/attrs.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{% if paint_logout %}
+  {% if attributes %}
+    <p>You have the following attributes:</p>
+    <table class="table table-striped">
+      <thead>
+        <th>Name</th><th>Values</th>
+      </thead>
+      <tbody>
+        {% for attr in attributes %}
+          <tr><td>{{ attr.0 }}</td>
+          <td><ul class="list-unstyled">
+            {% for val in attr.1 %}
+              <li>{{ val }}</li>
+            {% endfor %}
+          </ul></td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <div class="alert alert-danger" role="alert">You don't have any attributes</div>
+  {% endif %}
+  <a href="/?slo" class="btn btn-danger">Logout</a>
+{% else %}
+  <a href="/?sso2" class="btn btn-primary">Login and access again to this page</a>
+{% endif %}
+
+{% endblock %}

--- a/demo-bottle/templates/base.html
+++ b/demo-bottle/templates/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>A Python SAML Toolkit by OneLogin demo</title>
+
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="container">
+      <h1>A Python SAML Toolkit by OneLogin demo</h1>
+
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/demo-bottle/templates/index.html
+++ b/demo-bottle/templates/index.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{% if errors %}
+  <div class="alert alert-danger" role="alert">
+    <strong>Errors:</strong>
+    <ul class="list-unstyled">
+        {% for err in errors %}
+          <li>{{err}}</li>
+        {% endfor %}
+    </ul>
+  </div>
+{% endif %}
+
+{% if not_auth_warn %}
+  <div class="alert alert-danger" role="alert">Not authenticated</div>
+{% endif %}
+
+{% if success_slo %}
+  <div class="alert alert-success" role="alert">Successfully logged out</div>
+{% endif %}
+
+{% if paint_logout %}
+  {% if attributes %}
+    <table class="table table-striped">
+      <thead>
+        <th>Name</th><th>Values</th>
+      </thead>
+      <tbody>
+        {% for attr in attributes %}
+          <tr><td>{{ attr.0 }}</td>
+          <td><ul class="list-unstyled">
+            {% for val in attr.1 %}
+              <li>{{ val }}</li>
+            {% endfor %}
+          </ul></td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <div class="alert alert-danger" role="alert">You don't have any attributes</div>
+  {% endif %}
+  <a href="/?slo" class="btn btn-danger">Logout</a>
+{% else %}
+  <a href="/?sso" class="btn btn-primary">Login</a> <a href="?sso2" class="btn btn-info">Login and access to attrs page</a>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
I made demo-bottle, which uses [bottle](http://bottlepy.org/docs/dev/index.html), based on demo-flask.

Most parts are same with demo-flask, however, I changed acs to be new url(/acs) because bottle doesn't support to get url query params from POST request.

Also, I added ready-to-go localhost SSL example.

Please review the code.
Thank you.