### PR TITLE
Remove M2Crypto dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Installation
 ### Dependences ###
 
  * python 2.7
- * [M2Crypto](https://pypi.python.org/pypi/M2Crypto)  A Python crypto and SSL toolkit (depends on openssl, swig)
  * [dm.xmlsec.binding](https://pypi.python.org/pypi/dm.xmlsec.binding)  Cython/lxml based binding for the XML security library (depends on python-dev libxml2-dev libxmlsec1-dev)
  * [isodate](https://pypi.python.org/pypi/isodate)  An ISO 8601 date/time/duration parser and formater
  * [defusedxml](https://pypi.python.org/pypi/defusedxml)  XML bomb protection for Python stdlib modules

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'M2Crypto==0.22.3',
         'dm.xmlsec.binding==1.3.2',
         'isodate==0.5.0',
         'defusedxml==0.4.1',


### PR DESCRIPTION
We had some trouble with SWIG in our production environment (heroku).

I started wondering if it'd be easier to replace python-saml's use of M2Crypto with another (non-swig) crypto implementation.

After a little looking, I was unable to find anything in need of replacing. I asked someone more familiar with crypto APIs, and they couldn't find where python-saml was using M2Crypto either.

I removed M2Crypto from `install_requires`. We've now got a working SAML flow with no apparent error.

Would you be willing to release a new version without this dependency?