### PR TITLE
Fix creation of metadata with no SLS, when using settings.get_sp_metadata()

### DIFF
--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -74,7 +74,7 @@ class OneLogin_Saml2_Metadata(object):
             organization = {}
 
         sls = ''
-        if 'singleLogoutService' in sp:
+        if 'singleLogoutService' in sp and 'url' in sp['singleLogoutService']:
             sls = """        <md:SingleLogoutService Binding="%(binding)s"
                                 Location="%(location)s" />\n""" % \
                 {

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -64,7 +64,7 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
 
         security['authnRequestsSigned'] = True
         security['wantAssertionsSigned'] = True
-        del sp_data['singleLogoutService']
+        del sp_data['singleLogoutService']['url']
 
         metadata2 = OneLogin_Saml2_Metadata.builder(
             sp_data, security['authnRequestsSigned'],


### PR DESCRIPTION
Currently, if one wishes to generate SAML metadata using:

```python
saml_settings = OneLogin_Saml2_Settings(config)
metadata = saml_settings.get_sp_metadata()
```

an error will occur if your settings do not specify a `singleLogoutService` URL in the config. This is meant to be optional, but the settings parser always adds an empty `singleLogoutService` dict to the settings dict, which gets interpreted by other parts of the code as meaning that `singleLogoutService` should be used. The fix checks for the presence of `settings['singleLogoutService']['url']`, which should only be present when the user actually wants to use a `singleLogoutService`.

-------
This is a contribution from edX, developed by OpenCraft as part of bringing integrated SAML support to the edX platform, via a new python-social-auth SAML backend.