### PR TITLE
NameIDFormat/NameIDPolicy Improvements

### DIFF
--- a/demo-django/saml/settings.json
+++ b/demo-django/saml/settings.json
@@ -11,7 +11,7 @@
             "url": "https://<sp_domain>/?sls",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDFormats": ["urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"],
         "x509cert": "",
         "privateKey": ""
     },
@@ -25,6 +25,8 @@
             "url": "https://app.onelogin.com/trust/saml2/http-redirect/slo/<onelogin_connector_id>",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
+        "NameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDPolicyAllowCreate": true,
         "x509cert": "<onelogin_connector_cert>"
     }
 }

--- a/demo-flask/saml/settings.json
+++ b/demo-flask/saml/settings.json
@@ -11,7 +11,7 @@
             "url": "https://<sp_domain>/?sls",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDFormats": ["urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"],
         "x509cert": "",
         "privateKey": ""
     },
@@ -25,6 +25,8 @@
             "url": "https://app.onelogin.com/trust/saml2/http-redirect/slo/<onelogin_connector_id>",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
+        "NameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDPolicyAllowCreate": true,
         "x509cert": "<onelogin_connector_cert>"
     }
 }

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -64,7 +64,7 @@ class OneLogin_Saml2_Logout_Request(object):
                 cert = idp_data['x509cert']
 
             if name_id is not None:
-                nameIdFormat = sp_data['NameIDFormat']
+                nameIdFormat = idp_data['NameIDPolicyFormat']
             else:
                 name_id = idp_data['entityId']
                 nameIdFormat = OneLogin_Saml2_Constants.NAMEID_ENTITY

--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -119,13 +119,18 @@ class OneLogin_Saml2_Metadata(object):
                 contacts_info.append(contact)
             str_contacts = '\n'.join(contacts_info)
 
+        str_nameid_formats = ''
+        for name_id_format in sp['NameIDFormats']:
+            str_nameid_formats += '        <md:NameIDFormat>%s</md:NameIDFormat>\n' % name_id_format
+
         metadata = """<?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
                      validUntil="%(valid)s"
                      cacheDuration="%(cache)s"
                      entityID="%(entity_id)s">
     <md:SPSSODescriptor AuthnRequestsSigned="%(authnsign)s" WantAssertionsSigned="%(wsign)s" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-%(sls)s        <md:NameIDFormat>%(name_id_format)s</md:NameIDFormat>
+        %(sls)s
+        %(str_nameid_formats)s
         <md:AssertionConsumerService Binding="%(binding)s"
                                      Location="%(location)s"
                                      index="1" />
@@ -139,7 +144,7 @@ class OneLogin_Saml2_Metadata(object):
                 'entity_id': sp['entityId'],
                 'authnsign': str_authnsign,
                 'wsign': str_wsign,
-                'name_id_format': sp['NameIDFormat'],
+                'str_nameid_formats': str_nameid_formats,
                 'binding': sp['assertionConsumerService']['binding'],
                 'location': sp['assertionConsumerService']['url'],
                 'sls': sls,

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -287,7 +287,7 @@ class OneLogin_Saml2_Response(object):
             if nameid_nodes:
                 nameid = nameid_nodes[0]
         if nameid is None:
-            raise Exception('Not NameID found in the assertion of the Response')
+            return {'Value': None}
 
         nameid_data = {'Value': nameid.text}
         for attr in ['Format', 'SPNameQualifier', 'NameQualifier']:

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -261,8 +261,19 @@ class OneLogin_Saml2_Settings(object):
             self.__sp['singleLogoutService']['binding'] = OneLogin_Saml2_Constants.BINDING_HTTP_REDIRECT
 
         # Related to nameID
-        if 'NameIDFormat' not in self.__sp:
-            self.__sp['NameIDFormat'] = OneLogin_Saml2_Constants.NAMEID_PERSISTENT
+        if 'NameIDFormats' not in self.__sp:
+            # Check if the older config setting, single NameIDFormat is present:
+            if 'NameIDFormat' in self.__sp:
+                self.__sp['NameIDFormats'] = [self.__sp['NameIDFormat']]
+            else:
+                self.__sp['NameIDFormats'] = [OneLogin_Saml2_Constants.NAMEID_PERSISTENT]
+        if 'NameIDPolicyFormat' not in self.__idp:
+            # Check for the old-style setting 'NameIDFormat' which set both NameIDFormats and NameIDPolicyFormat:
+            if 'NameIDFormat' in self.__sp:
+                self.__idp['NameIDPolicyFormat'] = self.__sp.pop('NameIDFormat')
+                self.__idp['NameIDPolicyAllowCreate'] = True
+        if 'NameIDPolicyAllowCreate' not in self.__idp:
+            self.__idp['NameIDPolicyAllowCreate'] = False  # False is the default according to the spec
         if 'nameIdEncrypted' not in self.__security:
             self.__security['nameIdEncrypted'] = False
 

--- a/tests/settings/settings1.json
+++ b/tests/settings/settings1.json
@@ -10,7 +10,7 @@
         "singleLogoutService": {
             "url": "http://stuff.com/endpoints/endpoints/sls.php"
         },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
+        "NameIDFormats": ["urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"]
     },
     "idp": {
         "entityId": "http://idp.example.com/",
@@ -20,6 +20,8 @@
         "singleLogoutService": {
             "url": "http://idp.example.com/SingleLogoutService.php"
         },
+        "NameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDPolicyAllowCreate": true,
         "x509cert": "MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo"
     },
     "security": {

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -74,11 +74,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_nameid.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
-            response_4.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', e.message)
+        self.assertIsNone(response_4.get_nameid())
 
     def testGetNameIdData(self):
         """
@@ -116,11 +112,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_nameid.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
-            response_4.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', e.message)
+        data = response_4.get_nameid_data()
+        self.assertEqual(data, {'Value': None})
 
     def testCheckStatus(self):
         """

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -49,7 +49,9 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(settings_info)
         self.assertEqual(len(settings.get_errors()), 0)
 
-        del settings_info['sp']['NameIDFormat']
+        del settings_info['sp']['NameIDFormats']
+        del settings_info['idp']['NameIDPolicyFormat']
+        del settings_info['idp']['NameIDPolicyAllowCreate']
         del settings_info['idp']['x509cert']
         settings_info['idp']['certFingerprint'] = 'afe71c28ef740bc87425be13a2263d37971daA1f9'
         settings = OneLogin_Saml2_Settings(settings_info)
@@ -507,11 +509,15 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertIn('entityId', idp_data)
         self.assertIn('singleSignOnService', idp_data)
         self.assertIn('singleLogoutService', idp_data)
+        self.assertIn('NameIDPolicyFormat', idp_data)
+        self.assertIn('NameIDPolicyAllowCreate', idp_data)
         self.assertIn('x509cert', idp_data)
 
         self.assertEqual('http://idp.example.com/', idp_data['entityId'])
         self.assertEqual('http://idp.example.com/SSOService.php', idp_data['singleSignOnService']['url'])
         self.assertEqual('http://idp.example.com/SingleLogoutService.php', idp_data['singleLogoutService']['url'])
+        self.assertEqual('urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified', idp_data['NameIDPolicyFormat'])
+        self.assertTrue(idp_data['NameIDPolicyAllowCreate'])
 
         x509cert = 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo'
         formated_x509_cert = OneLogin_Saml2_Utils.format_cert(x509cert)
@@ -528,12 +534,12 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertIn('entityId', sp_data)
         self.assertIn('assertionConsumerService', sp_data)
         self.assertIn('singleLogoutService', sp_data)
-        self.assertIn('NameIDFormat', sp_data)
+        self.assertIn('NameIDFormats', sp_data)
 
         self.assertEqual('http://stuff.com/endpoints/metadata.php', sp_data['entityId'])
         self.assertEqual('http://stuff.com/endpoints/endpoints/acs.php', sp_data['assertionConsumerService']['url'])
         self.assertEqual('http://stuff.com/endpoints/endpoints/sls.php', sp_data['singleLogoutService']['url'])
-        self.assertEqual('urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified', sp_data['NameIDFormat'])
+        self.assertEqual(['urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified'], sp_data['NameIDFormats'])
 
     def testGetSecurityData(self):
         """


### PR DESCRIPTION
Currently, python-saml has only one setting, "NameIDFormat" to control NameIDs. I have made a few changes:

A. For the SP, the `NameIDFormat` (string) setting is replaced with `NameIDFormats` (list), because [the SAML spec](http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) says the `NameIDFormat` can be specified zero or more times (0,1,2,3,4, ...) and is intended to list *all* NameID formats accepted by the SP. As our own use case for SAML requires working with multiple IdPs, it is important that we can configure our metadata to list many accepted formats, or none at all. For backwards compatibility, the `NameIDFormat` (string) setting will still be accepted.
B. `NameIDPolicyFormat` and `NameIDPolicyAllowCreate` are two new settings to control the optional `NameIDPolicy` element in authn requests. If the old `NameIDFormat` setting is used, these will automatically be set to match. Otherwise, the new default is to not specify a `NameIDPolicy` at all, which is the default stated [in the spec](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). I also put these policy settings in the `idp` settings, so that they can be changed per-provider for those working with multiple IdPs.

-------
This is a contribution from edX, developed by OpenCraft as part of bringing integrated SAML support to the edX platform, via a new python-social-auth SAML backend.