### PR TITLE
Allow configuration of metadata caching/expiry via settings

### DIFF
--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -266,6 +266,12 @@ class OneLogin_Saml2_Settings(object):
         if 'nameIdEncrypted' not in self.__security:
             self.__security['nameIdEncrypted'] = False
 
+        # Metadata format
+        if 'metadataValidUntil' not in self.__security.keys():
+            self.__security['metadataValidUntil'] = None  # None means use default
+        if 'metadataCacheDuration' not in self.__security.keys():
+            self.__security['metadataCacheDuration'] = None  # None means use default
+
         # Sign provided
         if 'authnRequestsSigned' not in self.__security.keys():
             self.__security['authnRequestsSigned'] = False
@@ -548,7 +554,9 @@ class OneLogin_Saml2_Settings(object):
         """
         metadata = OneLogin_Saml2_Metadata.builder(
             self.__sp, self.__security['authnRequestsSigned'],
-            self.__security['wantAssertionsSigned'], None, None,
+            self.__security['wantAssertionsSigned'],
+            self.__security['metadataValidUntil'],
+            self.__security['metadataCacheDuration'],
             self.get_contacts(), self.get_organization()
         )
         cert = self.get_sp_cert()

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -84,14 +84,42 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
             sp_data, security['authnRequestsSigned'],
             security['wantAssertionsSigned'],
             '2014-10-01T11:04:29Z',
-            'PT1412593469S',
+            'P1Y',
             contacts,
             organization
         )
         self.assertIsNotNone(metadata3)
         self.assertIn('<md:SPSSODescriptor', metadata3)
-        self.assertIn('cacheDuration="PT1412593469S"', metadata3)
+        self.assertIn('cacheDuration="P1Y"', metadata3)
         self.assertIn('validUntil="2014-10-01T11:04:29Z"', metadata3)
+
+        # Test no validUntil, only cacheDuration:
+        metadata4 = OneLogin_Saml2_Metadata.builder(
+            sp_data, security['authnRequestsSigned'],
+            security['wantAssertionsSigned'],
+            '',
+            86400 * 10,  # 10 days
+            contacts,
+            organization
+        )
+        self.assertIsNotNone(metadata4)
+        self.assertIn('<md:SPSSODescriptor', metadata4)
+        self.assertIn('cacheDuration="PT864000S"', metadata4)
+        self.assertNotIn('validUntil', metadata4)
+
+        # Test no cacheDuration, only validUntil:
+        metadata5 = OneLogin_Saml2_Metadata.builder(
+            sp_data, security['authnRequestsSigned'],
+            security['wantAssertionsSigned'],
+            '2014-10-01T11:04:29Z',
+            '',
+            contacts,
+            organization
+        )
+        self.assertIsNotNone(metadata5)
+        self.assertIn('<md:SPSSODescriptor', metadata5)
+        self.assertNotIn('cacheDuration', metadata5)
+        self.assertIn('validUntil="2014-10-01T11:04:29Z"', metadata5)
 
     def testSignMetadata(self):
         """


### PR DESCRIPTION
Curently, python-saml does not allow users to set the time period for which metadata is valid using settings. I have added two new settings to allow the user to control the default expiry date and/or maximum cache time. In addition, you can opt to leave one, the other, or both unspecified. Although leaving both unspecified is against the spec, it is commonly done and is helpful for integration tests and development environments.

I also found and fixed a bug: the `cacheDuration` attribute in the XML is supposed to be a duration value like `PT86400S` (Period of Time 86400 Seconds - i.e. one day), and IdP implementations are required to record the time at which they fetched the metadata in order to compute the cache expiry time. However, the code was instead putting an absolute timestamp in this field, which would get interpreted as an extremely long maximum cache time (45+ years).

-------
This is a contribution from edX, developed by OpenCraft as part of bringing integrated SAML support to the edX platform, via a new python-social-auth SAML backend.