### PR TITLE
Make idp settings optional

### DIFF
--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -196,8 +196,9 @@ class OneLogin_Saml2_Settings(object):
         if len(errors) == 0:
             self.__errors = []
             self.__sp = settings['sp']
-            self.__idp = settings['idp']
 
+            if 'idp' in settings:
+                self.__idp = settings['idp']
             if 'strict' in settings:
                 self.__strict = settings['strict']
             if 'debug' in settings:


### PR DESCRIPTION
Just a tiny little change to make the IDP settings fully optional (for when `sp_validation_only=True`).