### PR TITLE
Fix exception 'Unsupported settings object while initializing OneLogin_Saml2_Auth with existing Onelogin_Saml2_Settings object.

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -15,6 +15,7 @@ from base64 import b64encode
 from urllib import quote_plus
 
 import dm.xmlsec.binding as xmlsec
+import copy
 
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.response import OneLogin_Saml2_Response
@@ -50,7 +51,6 @@ class OneLogin_Saml2_Auth(object):
         :type custom_base_path: string
         """
         self.__request_data = request_data
-        self.__settings = OneLogin_Saml2_Settings(old_settings, custom_base_path)
         self.__attributes = []
         self.__nameid = None
         self.__session_index = None
@@ -59,6 +59,15 @@ class OneLogin_Saml2_Auth(object):
         self.__errors = []
         self.__error_reason = None
         self.__last_request_id = None
+
+        if old_settings is None:
+            self.__settings(custom_base_path=custom_base_path)
+        elif isinstance(old_settings, dict):
+            self.__settings = OneLogin_Saml2_Settings(settings=old_settings, custom_base_path=custom_base_path)
+        elif isinstance(old_settings, OneLogin_Saml2_Settings):
+            self.__settings = copy.deepcopy(old_settings)
+        else:
+            raise Exception('Unsupported settings object')
 
     def get_settings(self):
         """

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -65,7 +65,7 @@ class OneLogin_Saml2_Settings(object):
         - Loads settings info from settings file or array/object provided
 
         :param settings: SAML Toolkit Settings
-        :type settings: dict|object
+        :type settings: dict
 
         :param custom_base_path: Path where are stored the settings file and the cert folder
         :type custom_base_path: string


### PR DESCRIPTION
- Onelogin_Saml2_Settings constructor doesn't actually support copying from other Onelogin_Saml2_Settings object, it can only be initialized from a dict (or from files). Fixed docstring to reflect this.
- Updated OneLogin_Saml2_Auth constructor to use deepcopy in case old_settings is an instance of Onelogin_Saml2_Settings