### PR TITLE
Allow custom valid_sign method

### DIFF
--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -209,7 +209,8 @@ class OneLogin_Saml2_Response(object):
                         document_to_validate = self.decrypted_document
                     else:
                         document_to_validate = self.document
-                if not OneLogin_Saml2_Utils.validate_sign(document_to_validate, cert, fingerprint, fingerprintalg):
+                validate_sign = self.__settings.get_validate_sign()
+                if not validate_sign(document_to_validate, cert, fingerprint, fingerprintalg):
                     raise Exception('Signature validation failed. SAML Response rejected')
             else:
                 raise Exception('No Signature found. SAML Response rejected')

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -80,6 +80,7 @@ class OneLogin_Saml2_Settings(object):
         self.__contacts = {}
         self.__organization = {}
         self.__errors = []
+        self.__validate_sign = None
 
         self.__load_paths(base_path=custom_base_path)
         self.__update_paths(settings)
@@ -211,6 +212,8 @@ class OneLogin_Saml2_Settings(object):
                 self.__contacts = settings['contactPerson']
             if 'organization' in settings:
                 self.__organization = settings['organization']
+            if 'validate_sign' in settings:
+                self.__validate_sign = settings['validate_sign']
 
             self.__add_default_values()
             return True
@@ -342,6 +345,10 @@ class OneLogin_Saml2_Settings(object):
                 errors += self.check_idp_settings(settings)
             sp_errors = self.check_sp_settings(settings)
             errors += sp_errors
+
+        if 'validate_sign' in settings \
+                and not callable(settings['validate_sign']):
+            errors.append('validate_sign_not_a_function')
 
         return errors
 
@@ -793,3 +800,12 @@ class OneLogin_Saml2_Settings(object):
         :rtype: boolean
         """
         return self.__debug
+
+    def get_validate_sign(self):
+        """
+        Returns custom validate_sign method if specify or the default method
+
+        :return: a validate_sign method
+        :rtype: function
+        """
+        return self.__validate_sign or OneLogin_Saml2_Utils.validate_sign

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1225,6 +1225,39 @@ bP0z0zvDEQnnt/VUWFEBLSJq4Z4Nre8LFmS2
                 'script_name': 'newonelogin/demo1/index.php?acs'
             }))
 
+    def testCustomValidateSign(self):
+        """
+        Test custom signature validation when specify validate_sign in settings.
+        """
+
+        xml = self.file_contents(join(self.data_path, 'responses', 'valid_response.xml.base64'))
+
+        def validate_sign(doc, cert, *args, **kwargs):
+            return cert == OneLogin_Saml2_Utils.format_cert('WeNeedCustomValidateSign')
+
+        # normal settings
+        settings_info = self.loadSettingsJSON()
+        settings = OneLogin_Saml2_Settings(settings_info)
+
+        # should be valid as always
+        response = OneLogin_Saml2_Response(settings, xml)
+        self.assertTrue(response.is_valid(self.get_request_data()))
+
+        # settings with custom validate_sign method
+        settings_info['validate_sign'] = validate_sign
+        settings = OneLogin_Saml2_Settings(settings_info)
+
+        # not valid according our custom valid_sign method
+        response = OneLogin_Saml2_Response(settings, xml)
+        self.assertFalse(response.is_valid(self.get_request_data()))
+
+        settings_info['idp']['x509cert'] = 'WeNeedCustomValidateSign'
+        settings = OneLogin_Saml2_Settings(settings_info)
+
+        # valid with our custom valid_sign method
+        response = OneLogin_Saml2_Response(settings, xml)
+        self.assertTrue(response.is_valid(self.get_request_data()))
+
 
 if __name__ == '__main__':
     if is_running_under_teamcity():

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -704,6 +704,30 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         settings_3 = OneLogin_Saml2_Settings(settings_info)
         self.assertTrue(settings_3.is_debug_active())
 
+    def testCustomValidateSign(self):
+        """
+        Test custom validate_sign settings can only be a function.
+        """
+        settings_info = self.loadSettingsJSON()
+
+        # set invalid cutsom validate_sign method
+        settings_info['validate_sign'] = 'not a function'
+
+        # check it can't load
+        with self.assertRaisesRegexp(OneLogin_Saml2_Error,
+                                     'Invalid dict settings: validate_sign_not_a_function'):
+            OneLogin_Saml2_Settings(settings_info)
+
+        def validate_sign(doc, cert, *args, **kwargs):
+            return True
+
+        # set valid cutsom validate_sign method
+        settings_info['validate_sign'] = validate_sign
+
+        # check it can load
+        settings = OneLogin_Saml2_Settings(settings_info)
+        self.assertEqual(settings.get_validate_sign(), validate_sign)
+
 
 if __name__ == '__main__':
     if is_running_under_teamcity():


### PR DESCRIPTION
In some cases, assertion responses can be validated with the xmlsec1 system library but not with the xmlsec python binding.

In that PR we allow the developpers to implement a custom validation method. Then they will be able to validate an assertion response with Popen.subprocess('xmlsec1 ...'), for example, or whatever.