### PR TITLE
Feature/bugfix adfs

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -111,7 +111,7 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SAML_RESPONSE_NOT_FOUND
             )
 
-    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None):
+    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None, lowercase_urlencoding=False):
         """
         Process the SAML Logout Response / Logout Request sent by the IdP.
 
@@ -127,7 +127,7 @@ class OneLogin_Saml2_Auth(object):
 
         if 'get_data' in self.__request_data and 'SAMLResponse' in self.__request_data['get_data']:
             logout_response = OneLogin_Saml2_Logout_Response(self.__settings, self.__request_data['get_data']['SAMLResponse'])
-            if not logout_response.is_valid(self.__request_data, request_id):
+            if not logout_response.is_valid(self.__request_data, request_id, lowercase_urlencoding=lowercase_urlencoding):
                 self.__errors.append('invalid_logout_response')
                 self.__error_reason = logout_response.get_error()
             elif logout_response.get_status() != OneLogin_Saml2_Constants.STATUS_SUCCESS:
@@ -137,7 +137,7 @@ class OneLogin_Saml2_Auth(object):
 
         elif 'get_data' in self.__request_data and 'SAMLRequest' in self.__request_data['get_data']:
             logout_request = OneLogin_Saml2_Logout_Request(self.__settings, self.__request_data['get_data']['SAMLRequest'])
-            if not logout_request.is_valid(self.__request_data):
+            if not logout_request.is_valid(self.__request_data, lowercase_urlencoding=lowercase_urlencoding):
                 self.__errors.append('invalid_logout_request')
                 self.__error_reason = logout_request.get_error()
             else:

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -111,7 +111,7 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SAML_RESPONSE_NOT_FOUND
             )
 
-    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None, lowercase_urlencoding=False):
+    def process_slo(self, keep_local_session=False, request_id=None, delete_session_cb=None):
         """
         Process the SAML Logout Response / Logout Request sent by the IdP.
 
@@ -127,7 +127,7 @@ class OneLogin_Saml2_Auth(object):
 
         if 'get_data' in self.__request_data and 'SAMLResponse' in self.__request_data['get_data']:
             logout_response = OneLogin_Saml2_Logout_Response(self.__settings, self.__request_data['get_data']['SAMLResponse'])
-            if not logout_response.is_valid(self.__request_data, request_id, lowercase_urlencoding=lowercase_urlencoding):
+            if not logout_response.is_valid(self.__request_data, request_id):
                 self.__errors.append('invalid_logout_response')
                 self.__error_reason = logout_response.get_error()
             elif logout_response.get_status() != OneLogin_Saml2_Constants.STATUS_SUCCESS:
@@ -137,7 +137,7 @@ class OneLogin_Saml2_Auth(object):
 
         elif 'get_data' in self.__request_data and 'SAMLRequest' in self.__request_data['get_data']:
             logout_request = OneLogin_Saml2_Logout_Request(self.__settings, self.__request_data['get_data']['SAMLRequest'])
-            if not logout_request.is_valid(self.__request_data, lowercase_urlencoding=lowercase_urlencoding):
+            if not logout_request.is_valid(self.__request_data):
                 self.__errors.append('invalid_logout_request')
                 self.__error_reason = logout_request.get_error()
             else:

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -251,7 +251,7 @@ class OneLogin_Saml2_Logout_Request(object):
             session_indexes.append(session_index_node.text)
         return session_indexes
 
-    def is_valid(self, request_data):
+    def is_valid(self, request_data, lowercase_urlencoding=False):
         """
         Checks if the Logout Request recieved is valid
         :param request_data: Request Data
@@ -316,10 +316,10 @@ class OneLogin_Saml2_Logout_Request(object):
                 else:
                     sign_alg = get_data['SigAlg']
 
-                signed_query = 'SAMLRequest=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLRequest')
+                signed_query = 'SAMLRequest=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLRequest', lowercase_urlencoding=lowercase_urlencoding)
                 if 'RelayState' in get_data:
-                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState'))
-                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1))
+                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState', lowercase_urlencoding=lowercase_urlencoding))
+                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1, lowercase_urlencoding=lowercase_urlencoding))
 
                 if 'x509cert' not in idp_data or idp_data['x509cert'] is None:
                     raise Exception('In order to validate the sign on the Logout Request, the x509cert of the IdP is required')

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -251,7 +251,7 @@ class OneLogin_Saml2_Logout_Request(object):
             session_indexes.append(session_index_node.text)
         return session_indexes
 
-    def is_valid(self, request_data, lowercase_urlencoding=False):
+    def is_valid(self, request_data):
         """
         Checks if the Logout Request recieved is valid
         :param request_data: Request Data
@@ -316,10 +316,10 @@ class OneLogin_Saml2_Logout_Request(object):
                 else:
                     sign_alg = get_data['SigAlg']
 
-                signed_query = 'SAMLRequest=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLRequest', lowercase_urlencoding=lowercase_urlencoding)
+                signed_query = 'SAMLRequest=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLRequest')
                 if 'RelayState' in get_data:
-                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState', lowercase_urlencoding=lowercase_urlencoding))
-                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1, lowercase_urlencoding=lowercase_urlencoding))
+                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState'))
+                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1))
 
                 if 'x509cert' not in idp_data or idp_data['x509cert'] is None:
                     raise Exception('In order to validate the sign on the Logout Request, the x509cert of the IdP is required')

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -68,7 +68,7 @@ class OneLogin_Saml2_Logout_Response(object):
         status = entries[0].attrib['Value']
         return status
 
-    def is_valid(self, request_data, request_id=None, lowercase_urlencoding=False):
+    def is_valid(self, request_data, request_id=None):
         """
         Determines if the SAML LogoutResponse is valid
         :param request_id: The ID of the LogoutRequest sent by this SP to the IdP
@@ -119,10 +119,10 @@ class OneLogin_Saml2_Logout_Response(object):
                 else:
                     sign_alg = get_data['SigAlg']
 
-                signed_query = 'SAMLResponse=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLResponse', lowercase_urlencoding=lowercase_urlencoding)
+                signed_query = 'SAMLResponse=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLResponse')
                 if 'RelayState' in get_data:
-                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState', lowercase_urlencoding=lowercase_urlencoding))
-                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1, lowercase_urlencoding=lowercase_urlencoding))
+                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState'))
+                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1))
 
                 if 'x509cert' not in idp_data or idp_data['x509cert'] is None:
                     raise Exception('In order to validate the sign on the Logout Response, the x509cert of the IdP is required')

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -68,7 +68,7 @@ class OneLogin_Saml2_Logout_Response(object):
         status = entries[0].attrib['Value']
         return status
 
-    def is_valid(self, request_data, request_id=None):
+    def is_valid(self, request_data, request_id=None, lowercase_urlencoding=False):
         """
         Determines if the SAML LogoutResponse is valid
         :param request_id: The ID of the LogoutRequest sent by this SP to the IdP
@@ -119,10 +119,10 @@ class OneLogin_Saml2_Logout_Response(object):
                 else:
                     sign_alg = get_data['SigAlg']
 
-                signed_query = 'SAMLResponse=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLResponse')
+                signed_query = 'SAMLResponse=%s' % OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SAMLResponse', lowercase_urlencoding=lowercase_urlencoding)
                 if 'RelayState' in get_data:
-                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState'))
-                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1))
+                    signed_query = '%s&RelayState=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'RelayState', lowercase_urlencoding=lowercase_urlencoding))
+                signed_query = '%s&SigAlg=%s' % (signed_query, OneLogin_Saml2_Utils.get_encoded_parameter(get_data, 'SigAlg', OneLogin_Saml2_Constants.RSA_SHA1, lowercase_urlencoding=lowercase_urlencoding))
 
                 if 'x509cert' not in idp_data or idp_data['x509cert'] is None:
                     raise Exception('In order to validate the sign on the Logout Response, the x509cert of the IdP is required')

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -1151,5 +1151,5 @@ class OneLogin_Saml2_Utils(object):
 
     @staticmethod
     def case_sensitive_urlencode(to_encode, lowercase=False):
-        encoded=quote_plus(to_encode)
+        encoded = quote_plus(to_encode)
         return re.sub(r"%[A-F0-9]{2}", lambda m: m.group(0).lower(), encoded) if lowercase else encoded

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -1127,13 +1127,15 @@ class OneLogin_Saml2_Utils(object):
             return False
 
     @staticmethod
-    def get_encoded_parameter(get_data, name, default=None, lowercase_urlencoding=False):
+    def get_encoded_parameter(get_data, name, default=None):
         """Return an url encoded get parameter value
         Prefer to extract the original encoded value directly from query_string since url
         encoding is not canonical. The encoding used by ADFS 3.0 is not compatible with
         python's quote_plus (ADFS produces lower case hex numbers and quote_plus produces
         upper case hex numbers)
         """
+        lowercase_urlencoding = get_data.get('lowercase_urlencoding', False)
+
         if name not in get_data:
             return OneLogin_Saml2_Utils.case_sensitive_urlencode(default, lowercase_urlencoding)
         if 'query_string' in get_data:

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -1135,10 +1135,10 @@ class OneLogin_Saml2_Utils(object):
         upper case hex numbers)
         """
         if name not in get_data:
-            return case_sensitive_urlencode(default, lowercase_urlencoding)
+            return OneLogin_Saml2_Utils.case_sensitive_urlencode(default, lowercase_urlencoding)
         if 'query_string' in get_data:
             return OneLogin_Saml2_Utils.extract_raw_query_parameter(get_data['query_string'], name)
-        return case_sensitive_urlencode(get_data[name], lowercase_urlencoding)
+        return OneLogin_Saml2_Utils.case_sensitive_urlencode(get_data[name], lowercase_urlencoding)
 
     @staticmethod
     def extract_raw_query_parameter(query_string, parameter, default=''):

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -1127,7 +1127,7 @@ class OneLogin_Saml2_Utils(object):
             return False
 
     @staticmethod
-    def get_encoded_parameter(get_data, name, default=None):
+    def get_encoded_parameter(get_data, name, default=None, lowercase_urlencoding=False):
         """Return an url encoded get parameter value
         Prefer to extract the original encoded value directly from query_string since url
         encoding is not canonical. The encoding used by ADFS 3.0 is not compatible with
@@ -1135,10 +1135,10 @@ class OneLogin_Saml2_Utils(object):
         upper case hex numbers)
         """
         if name not in get_data:
-            return quote_plus(default)
+            return case_sensitive_urlencode(default, lowercase_urlencoding)
         if 'query_string' in get_data:
             return OneLogin_Saml2_Utils.extract_raw_query_parameter(get_data['query_string'], name)
-        return quote_plus(get_data[name])
+        return case_sensitive_urlencode(get_data[name], lowercase_urlencoding)
 
     @staticmethod
     def extract_raw_query_parameter(query_string, parameter, default=''):
@@ -1147,3 +1147,8 @@ class OneLogin_Saml2_Utils(object):
             return m.group(1)
         else:
             return default
+
+    @staticmethod
+    def case_sensitive_urlencode(to_encode, lowercase=False):
+        encoded=quote_plus(to_encode)
+        return re.sub(r"%[A-F0-9]{2}", lambda m: m.group(0).lower(), encoded) if lowercase else encoded


### PR DESCRIPTION
This is a bugfix for the fact that Microsoft ADFS URL-Encodes SAML data as lowercase, and Python's urllib Url-Encodes as uppercase. This creates a signature verification mismatch and the LogoutRequest fails.

This bugfix passes a parameter (which defaults to `False` for backward compatibility) along the call of `process_slo()` for letting the user decide if the URL-Encoding should be processed as lowercase (ADFS_3.0-compatible) or uppercase (default).

This might not fit in the global architecture of `onelogin`; Feel free to modify in order to make it "production-ready" ;-)