### PR TITLE
Work-around for Issue #120, xmlsec.initialize

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -14,14 +14,14 @@ Initializes the SP SAML instance
 from base64 import b64encode
 from urllib import quote_plus
 
-import dm.xmlsec.binding as xmlsec
+# import dm.xmlsec.binding as xmlsec
 
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.response import OneLogin_Saml2_Response
 from onelogin.saml2.errors import OneLogin_Saml2_Error
 from onelogin.saml2.logout_response import OneLogin_Saml2_Logout_Response
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
-from onelogin.saml2.utils import OneLogin_Saml2_Utils
+from onelogin.saml2.utils import OneLogin_Saml2_Utils, xmlsec
 from onelogin.saml2.logout_request import OneLogin_Saml2_Logout_Request
 from onelogin.saml2.authn_request import OneLogin_Saml2_Authn_Request
 
@@ -433,7 +433,7 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SP_CERTS_NOT_FOUND
             )
 
-        xmlsec.initialize('openssl')
+        # xmlsec.initialize() # already done in utils module
 
         dsig_ctx = xmlsec.DSigCtx()
         dsig_ctx.signKey = xmlsec.Key.loadMemory(key, xmlsec.KeyDataFormatPem, None)

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -433,7 +433,7 @@ class OneLogin_Saml2_Auth(object):
                 OneLogin_Saml2_Error.SP_CERTS_NOT_FOUND
             )
 
-        xmlsec.initialize()
+        xmlsec.initialize('openssl')
 
         dsig_ctx = xmlsec.DSigCtx()
         dsig_ctx.signKey = xmlsec.Key.loadMemory(key, xmlsec.KeyDataFormatPem, None)

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -629,7 +629,7 @@ class OneLogin_Saml2_Utils(object):
             xml = name_id_container.toxml()
             elem = fromstring(xml)
 
-            xmlsec.initialize('openssl')
+            # xmlsec.initialize('openssl') # done when the module is loaded
 
             if debug:
                 xmlsec.set_error_callback(print_xmlsec_errors)

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -38,6 +38,7 @@ if not globals().get('xmlsec_setup', False):
     xmlsec.initialize()
     globals()['xmlsec_setup'] = True
 
+
 def print_xmlsec_errors(filename, line, func, error_object, error_subject, reason, msg):
     """
     Auxiliary method. It override the default xmlsec debug message.

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -626,7 +626,7 @@ class OneLogin_Saml2_Utils(object):
             xml = name_id_container.toxml()
             elem = fromstring(xml)
 
-            xmlsec.initialize()
+            xmlsec.initialize('openssl')
 
             if debug:
                 xmlsec.set_error_callback(print_xmlsec_errors)

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -34,6 +34,9 @@ from dm.xmlsec.binding.tmpl import EncData, Signature
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
 from onelogin.saml2.errors import OneLogin_Saml2_Error
 
+if not globals().get('xmlsec_setup', False):
+    xmlsec.initialize()
+    globals()['xmlsec_setup'] = True
 
 def print_xmlsec_errors(filename, line, func, error_object, error_subject, reason, msg):
     """

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -738,7 +738,7 @@ class OneLogin_Saml2_Utils(object):
         elif isinstance(encrypted_data, basestring):
             encrypted_data = fromstring(str(encrypted_data))
 
-        xmlsec.initialize()
+        # xmlsec.initialize()  # Initialized at the start of the module
 
         if debug:
             xmlsec.set_error_callback(print_xmlsec_errors)
@@ -813,7 +813,7 @@ class OneLogin_Saml2_Utils(object):
         else:
             raise Exception('Error parsing xml string')
 
-        xmlsec.initialize()
+        # xmlsec.initialize()  # Initialized at the start of the module
 
         if debug:
             xmlsec.set_error_callback(print_xmlsec_errors)
@@ -919,7 +919,7 @@ class OneLogin_Saml2_Utils(object):
             else:
                 raise Exception('Error parsing xml string')
 
-            xmlsec.initialize()
+            # xmlsec.initialize()  # Initialized at the start of the module
 
             if debug:
                 xmlsec.set_error_callback(print_xmlsec_errors)
@@ -985,7 +985,7 @@ class OneLogin_Saml2_Utils(object):
             else:
                 raise Exception('Error parsing xml string')
 
-            xmlsec.initialize()
+            # xmlsec.initialize()  # Initialized at the start of the module
 
             if debug:
                 xmlsec.set_error_callback(print_xmlsec_errors)
@@ -1038,7 +1038,7 @@ class OneLogin_Saml2_Utils(object):
         :type: bool
         """
         try:
-            xmlsec.initialize()
+            # xmlsec.initialize()  # Initialized at the start of the module
 
             if debug:
                 xmlsec.set_error_callback(print_xmlsec_errors)
@@ -1103,7 +1103,7 @@ class OneLogin_Saml2_Utils(object):
         :type: bool
         """
         try:
-            xmlsec.initialize()
+            # xmlsec.initialize()  # Initialized at the start of the module
 
             if debug:
                 xmlsec.set_error_callback(print_xmlsec_errors)


### PR DESCRIPTION
When running the python-saml code in a stand-alone django development server everything works. As soon as I used the same code in a server environment, the python-saml code would fail in a similar fashion to ticket #120 . Both were Ubuntu machines running a current version (same python version) and both had the same libraries installed using apt and both were running the same python libraries in virtual environments.

I made changes to the python-saml code that limit initialization to the utils module and importing xmlsec from utils in other modules so that utils is the only place where xmlsec is initialized. I notice that there are updates to the thread since I made these changes so maybe another solution is in the works? My code is currently working.