### PR TITLE
Update license field in setup.py match LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,14 +3,15 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     author='OneLogin',
     author_email='support@onelogin.com',
-    license='MIT',
+    license='BSD',
     url='https://github.com/onelogin/python-saml',
     packages=['onelogin','onelogin/saml2'],
     include_package_data=True,


### PR DESCRIPTION
The setup.py field previouly set license to MIT but
the LICENSE file contains a 2-clause BSD license.

Also, replace the <organisation> placeholder in the license
file with "copyright holder" to match:
https://opensource.org/licenses/BSD-3-Clause