### PR TITLE
Add logging events to track interactions

### DIFF
--- a/src/onelogin/__init__.py
+++ b/src/onelogin/__init__.py
@@ -21,3 +21,7 @@ Supports:
 * Enable a Single Logout Service endpoint.
 * Publish the SP metadata (which can be signed).
 """
+
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/onelogin/saml2/__init__.py
+++ b/src/onelogin/saml2/__init__.py
@@ -21,3 +21,7 @@ Supports:
 * Enable a Single Logout Service endpoint.
 * Publish the SP metadata (which can be signed).
 """
+
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
We have a use case where we'd like to be able to pull more data out of `python-saml`, especially to help analyze cases where single sign-on fails for our users. This pull request adds some basic analytical logging at the info level, using the Python standard library's `logging` module, which is also used in Django and Flask.