### PR TITLE
Optionally raise detailed exceptions vs. returning False

### DIFF
--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -25,6 +25,7 @@ from urllib import quote_plus
 from uuid import uuid4
 from xml.dom.minidom import Document, Element
 from defusedxml.minidom import parseString
+from functools import wraps
 
 import zlib
 
@@ -37,6 +38,24 @@ from onelogin.saml2.errors import OneLogin_Saml2_Error
 if not globals().get('xmlsec_setup', False):
     xmlsec.initialize()
     globals()['xmlsec_setup'] = True
+
+
+def return_false_on_exception(func):
+    """
+    Decorator. When applied to a function, it will, by default, suppress any exceptions
+    raised by that function and return False. It may be overridden by passing a
+    "raise_exceptions" keyword argument when calling the wrapped function.
+    """
+    @wraps(func)
+    def exceptfalse(*args, **kwargs):
+        if not kwargs.pop('raise_exceptions', False):
+            try:
+                return func(*args, **kwargs)
+            except Exception:
+                return False
+        else:
+            return func(*args, **kwargs)
+    return exceptfalse
 
 
 def print_xmlsec_errors(filename, line, func, error_object, error_subject, reason, msg):
@@ -866,6 +885,7 @@ class OneLogin_Saml2_Utils(object):
         return newdoc.saveXML(newdoc.firstChild)
 
     @staticmethod
+    @return_false_on_exception
     def validate_sign(xml, cert=None, fingerprint=None, fingerprintalg='sha1', validatecert=False, debug=False):
         """
         Validates a signature (Message or Assertion).
@@ -887,53 +907,54 @@ class OneLogin_Saml2_Utils(object):
 
         :param debug: Activate the xmlsec debug
         :type: bool
+
+        :param raise_exceptions: Whether to return false on failure or raise an exception
+        :type raise_exceptions: Boolean
         """
-        try:
-            if xml is None or xml == '':
-                raise Exception('Empty string supplied as input')
-            elif isinstance(xml, etree._Element):
-                elem = xml
-            elif isinstance(xml, Document):
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, Element):
-                xml.setAttributeNS(
-                    unicode(OneLogin_Saml2_Constants.NS_SAMLP),
-                    'xmlns:samlp',
-                    unicode(OneLogin_Saml2_Constants.NS_SAMLP)
-                )
-                xml.setAttributeNS(
-                    unicode(OneLogin_Saml2_Constants.NS_SAML),
-                    'xmlns:saml',
-                    unicode(OneLogin_Saml2_Constants.NS_SAML)
-                )
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, basestring):
-                elem = fromstring(str(xml))
-            else:
-                raise Exception('Error parsing xml string')
+        if xml is None or xml == '':
+            raise Exception('Empty string supplied as input')
+        elif isinstance(xml, etree._Element):
+            elem = xml
+        elif isinstance(xml, Document):
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, Element):
+            xml.setAttributeNS(
+                unicode(OneLogin_Saml2_Constants.NS_SAMLP),
+                'xmlns:samlp',
+                unicode(OneLogin_Saml2_Constants.NS_SAMLP)
+            )
+            xml.setAttributeNS(
+                unicode(OneLogin_Saml2_Constants.NS_SAML),
+                'xmlns:saml',
+                unicode(OneLogin_Saml2_Constants.NS_SAML)
+            )
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, basestring):
+            elem = fromstring(str(xml))
+        else:
+            raise Exception('Error parsing xml string')
 
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            xmlsec.addIDs(elem, ["ID"])
+        xmlsec.addIDs(elem, ["ID"])
 
-            signature_nodes = OneLogin_Saml2_Utils.query(elem, '/samlp:Response/ds:Signature')
+        signature_nodes = OneLogin_Saml2_Utils.query(elem, '/samlp:Response/ds:Signature')
 
-            if not len(signature_nodes) > 0:
-                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/samlp:Response/saml:Assertion/ds:Signature')
+        if not len(signature_nodes) > 0:
+            signature_nodes += OneLogin_Saml2_Utils.query(elem, '/samlp:Response/saml:Assertion/ds:Signature')
 
-            if len(signature_nodes) == 1:
-                signature_node = signature_nodes[0]
+        if len(signature_nodes) == 1:
+            signature_node = signature_nodes[0]
 
-                return OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug)
-            else:
-                return False
-        except Exception:
-            return False
+            return OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug, raise_exceptions=True)
+        else:
+            raise Exception('Expected exactly one signature node; got {}.'.format(len(signature_nodes)))
 
     @staticmethod
+    @return_false_on_exception
     def validate_metadata_sign(xml, cert=None, fingerprint=None, fingerprintalg='sha1', validatecert=False, debug=False):
         """
         Validates a signature of a EntityDescriptor.
@@ -955,53 +976,53 @@ class OneLogin_Saml2_Utils(object):
 
         :param debug: Activate the xmlsec debug
         :type: bool
+
+        :param raise_exceptions: Whether to return false on failure or raise an exception
+        :type raise_exceptions: Boolean
         """
-        try:
-            if xml is None or xml == '':
-                raise Exception('Empty string supplied as input')
-            elif isinstance(xml, etree._Element):
-                elem = xml
-            elif isinstance(xml, Document):
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, Element):
-                xml.setAttributeNS(
-                    unicode(OneLogin_Saml2_Constants.NS_MD),
-                    'xmlns:md',
-                    unicode(OneLogin_Saml2_Constants.NS_MD)
-                )
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, basestring):
-                elem = fromstring(str(xml))
-            else:
-                raise Exception('Error parsing xml string')
+        if xml is None or xml == '':
+            raise Exception('Empty string supplied as input')
+        elif isinstance(xml, etree._Element):
+            elem = xml
+        elif isinstance(xml, Document):
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, Element):
+            xml.setAttributeNS(
+                unicode(OneLogin_Saml2_Constants.NS_MD),
+                'xmlns:md',
+                unicode(OneLogin_Saml2_Constants.NS_MD)
+            )
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, basestring):
+            elem = fromstring(str(xml))
+        else:
+            raise Exception('Error parsing xml string')
 
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            xmlsec.addIDs(elem, ["ID"])
+        xmlsec.addIDs(elem, ["ID"])
 
-            signature_nodes = OneLogin_Saml2_Utils.query(elem, '/md:EntitiesDescriptor/ds:Signature')
+        signature_nodes = OneLogin_Saml2_Utils.query(elem, '/md:EntitiesDescriptor/ds:Signature')
+
+        if len(signature_nodes) == 0:
+            signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/ds:Signature')
 
             if len(signature_nodes) == 0:
-                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/ds:Signature')
+                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:SPSSODescriptor/ds:Signature')
+                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:IDPSSODescriptor/ds:Signature')
 
-                if len(signature_nodes) == 0:
-                    signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:SPSSODescriptor/ds:Signature')
-                    signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:IDPSSODescriptor/ds:Signature')
-
-            if len(signature_nodes) > 0:
-                for signature_node in signature_nodes:
-                    if not OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug):
-                        return False
-                return True
-            else:
-                return False
-        except Exception:
-            return False
+        if len(signature_nodes) > 0:
+            for signature_node in signature_nodes:
+                OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug, raise_exceptions=True)
+            return True
+        else:
+            raise Exception('Could not validate metadata signature: No signature nodes found.')
 
     @staticmethod
+    @return_false_on_exception
     def validate_node_sign(signature_node, elem, cert=None, fingerprint=None, fingerprintalg='sha1', validatecert=False, debug=False):
         """
         Validates a signature node.
@@ -1026,50 +1047,54 @@ class OneLogin_Saml2_Utils(object):
 
         :param debug: Activate the xmlsec debug
         :type: bool
+
+        :param raise_exceptions: Whether to return false on failure or raise an exception
+        :type raise_exceptions: Boolean
         """
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
+
+        xmlsec.addIDs(elem, ["ID"])
+
+        if (cert is None or cert == '') and fingerprint:
+            x509_certificate_nodes = OneLogin_Saml2_Utils.query(signature_node, '//ds:Signature/ds:KeyInfo/ds:X509Data/ds:X509Certificate')
+            if len(x509_certificate_nodes) > 0:
+                x509_certificate_node = x509_certificate_nodes[0]
+                x509_cert_value = x509_certificate_node.text
+                x509_fingerprint_value = OneLogin_Saml2_Utils.calculate_x509_fingerprint(x509_cert_value, fingerprintalg)
+                if fingerprint == x509_fingerprint_value:
+                    cert = OneLogin_Saml2_Utils.format_cert(x509_cert_value)
+
+        # Check if Reference URI is empty
+        # reference_elem = OneLogin_Saml2_Utils.query(signature_node, '//ds:Reference')
+        # if len(reference_elem) > 0:
+        #    if reference_elem[0].get('URI') == '':
+        #        reference_elem[0].set('URI', '#%s' % signature_node.getparent().get('ID'))
+
+        if cert is None or cert == '':
+            raise Exception('Could not validate node signature: No certificate provided.')
+
+        file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
+
+        if validatecert:
+            mngr = xmlsec.KeysMngr()
+            mngr.loadCert(file_cert.name, xmlsec.KeyDataFormatCertPem, xmlsec.KeyDataTypeTrusted)
+            dsig_ctx = xmlsec.DSigCtx(mngr)
+        else:
+            dsig_ctx = xmlsec.DSigCtx()
+            dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
+
+        file_cert.close()
+
+        dsig_ctx.setEnabledKeyData([xmlsec.KeyDataX509])
         try:
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
-
-            xmlsec.addIDs(elem, ["ID"])
-
-            if (cert is None or cert == '') and fingerprint:
-                x509_certificate_nodes = OneLogin_Saml2_Utils.query(signature_node, '//ds:Signature/ds:KeyInfo/ds:X509Data/ds:X509Certificate')
-                if len(x509_certificate_nodes) > 0:
-                    x509_certificate_node = x509_certificate_nodes[0]
-                    x509_cert_value = x509_certificate_node.text
-                    x509_fingerprint_value = OneLogin_Saml2_Utils.calculate_x509_fingerprint(x509_cert_value, fingerprintalg)
-                    if fingerprint == x509_fingerprint_value:
-                        cert = OneLogin_Saml2_Utils.format_cert(x509_cert_value)
-
-            # Check if Reference URI is empty
-            # reference_elem = OneLogin_Saml2_Utils.query(signature_node, '//ds:Reference')
-            # if len(reference_elem) > 0:
-            #    if reference_elem[0].get('URI') == '':
-            #        reference_elem[0].set('URI', '#%s' % signature_node.getparent().get('ID'))
-
-            if cert is None or cert == '':
-                return False
-
-            file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
-
-            if validatecert:
-                mngr = xmlsec.KeysMngr()
-                mngr.loadCert(file_cert.name, xmlsec.KeyDataFormatCertPem, xmlsec.KeyDataTypeTrusted)
-                dsig_ctx = xmlsec.DSigCtx(mngr)
-            else:
-                dsig_ctx = xmlsec.DSigCtx()
-                dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
-
-            file_cert.close()
-
-            dsig_ctx.setEnabledKeyData([xmlsec.KeyDataX509])
             dsig_ctx.verify(signature_node)
-            return True
         except Exception:
-            return False
+            raise Exception('Signature validation failed. SAML Response rejected')
+        return True
 
     @staticmethod
+    @return_false_on_exception
     def validate_binary_sign(signed_query, signature, cert=None, algorithm=OneLogin_Saml2_Constants.RSA_SHA1, debug=False):
         """
         Validates signed binary data (Used to validate GET Signature).
@@ -1089,31 +1114,31 @@ class OneLogin_Saml2_Utils(object):
 
         :param debug: Activate the xmlsec debug
         :type: bool
+
+        :param raise_exceptions: Whether to return false on failure or raise an exception
+        :type raise_exceptions: Boolean
         """
-        try:
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            dsig_ctx = xmlsec.DSigCtx()
+        dsig_ctx = xmlsec.DSigCtx()
 
-            file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
-            dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
-            file_cert.close()
+        file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
+        dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
+        file_cert.close()
 
-            # Sign the metadata with our private key.
-            sign_algorithm_transform_map = {
-                OneLogin_Saml2_Constants.DSA_SHA1: xmlsec.TransformDsaSha1,
-                OneLogin_Saml2_Constants.RSA_SHA1: xmlsec.TransformRsaSha1,
-                OneLogin_Saml2_Constants.RSA_SHA256: xmlsec.TransformRsaSha256,
-                OneLogin_Saml2_Constants.RSA_SHA384: xmlsec.TransformRsaSha384,
-                OneLogin_Saml2_Constants.RSA_SHA512: xmlsec.TransformRsaSha512
-            }
-            sign_algorithm_transform = sign_algorithm_transform_map.get(algorithm, xmlsec.TransformRsaSha1)
+        # Sign the metadata with our private key.
+        sign_algorithm_transform_map = {
+            OneLogin_Saml2_Constants.DSA_SHA1: xmlsec.TransformDsaSha1,
+            OneLogin_Saml2_Constants.RSA_SHA1: xmlsec.TransformRsaSha1,
+            OneLogin_Saml2_Constants.RSA_SHA256: xmlsec.TransformRsaSha256,
+            OneLogin_Saml2_Constants.RSA_SHA384: xmlsec.TransformRsaSha384,
+            OneLogin_Saml2_Constants.RSA_SHA512: xmlsec.TransformRsaSha512
+        }
+        sign_algorithm_transform = sign_algorithm_transform_map.get(algorithm, xmlsec.TransformRsaSha1)
 
-            dsig_ctx.verifyBinary(signed_query, sign_algorithm_transform, signature)
-            return True
-        except Exception:
-            return False
+        dsig_ctx.verifyBinary(signed_query, sign_algorithm_transform, signature)
+        return True
 
     @staticmethod
     def get_encoded_parameter(get_data, name, default=None, lowercase_urlencoding=False):


### PR DESCRIPTION
Currently, python-saml has a number of cases where methods simply return False on failure. This prevents error details from bubbling up and being saved for retrieval.

This change decorates those methods with a decorator that, by default, returns False when an exception is raised. However, internally to python-saml, those exceptions are raised and saved for retrieval with `get_last_error_reason`.

As a result, more detail is available for diagnostics, but the overall API is preserved, because, by default, those exceptions are suppressed when the methods in question are called directly.

Unit tests have been added to ensure that the appropriate exception is raised in all places where False is currently returned when the `raise_exceptions=True` keyword argument is passed, and existing tests checking that these methods return False when that keyword isn't passed remain as written.
