### PR TITLE
Add support for non-ascii fields in settings.

### DIFF
--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -173,7 +173,7 @@ class OneLogin_Saml2_Metadata(object):
                 contacts_info.append(contact)
             str_contacts = '\n'.join(contacts_info) + '\n'
 
-        metadata = """<?xml version="1.0"?>
+        metadata = u"""<?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
                      %(valid)s
                      %(cache)s
@@ -241,7 +241,7 @@ class OneLogin_Saml2_Metadata(object):
         if cert is None or cert == '':
             return metadata
         try:
-            xml = parseString(metadata)
+            xml = parseString(metadata.encode('utf-8'))
         except Exception as e:
             raise Exception('Error parsing metadata. ' + e.message)
 

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -75,7 +75,7 @@ class OneLogin_Saml2_Utils(object):
         :rtype: string
         """
 
-        return zlib.decompress(base64.b64decode(value), -15)
+        return zlib.decompress(base64.b64decode(value), -15).decode('utf-8')
 
     @staticmethod
     def deflate_and_base64_encode(value):
@@ -86,7 +86,7 @@ class OneLogin_Saml2_Utils(object):
         :returns: The deflated and encoded string
         :rtype: string
         """
-        return base64.b64encode(zlib.compress(value)[2:-4])
+        return base64.b64encode(zlib.compress(value.encode('utf-8'))[2:-4])
 
     @staticmethod
     def validate_xml(xml, schema, debug=False):
@@ -107,11 +107,11 @@ class OneLogin_Saml2_Utils(object):
         if isinstance(xml, Document):
             xml = xml.toxml()
         elif isinstance(xml, etree._Element):
-            xml = tostring(xml)
+            xml = tostring(xml, encoding='unicode')
 
         # Switch to lxml for schema validation
         try:
-            dom = fromstring(str(xml))
+            dom = fromstring(xml.encode('utf-8'))
         except Exception:
             return 'unloaded_xml'
 
@@ -130,7 +130,7 @@ class OneLogin_Saml2_Utils(object):
 
             return 'invalid_xml'
 
-        return parseString(etree.tostring(dom))
+        return parseString(etree.tostring(dom, encoding='unicode').encode('utf-8'))
 
     @staticmethod
     def format_cert(cert, heads=True):
@@ -655,7 +655,7 @@ class OneLogin_Saml2_Utils(object):
 
             edata = enc_ctx.encryptXml(enc_data, elem[0])
 
-            newdoc = parseString(etree.tostring(edata))
+            newdoc = parseString(etree.tostring(edata, encoding='unicode').encode('utf-8'))
 
             if newdoc.hasChildNodes():
                 child = newdoc.firstChild
@@ -791,7 +791,7 @@ class OneLogin_Saml2_Utils(object):
             elem = xml
         elif isinstance(xml, Document):
             xml = xml.toxml()
-            elem = fromstring(str(xml))
+            elem = fromstring(xml.encode('utf-8'))
         elif isinstance(xml, Element):
             xml.setAttributeNS(
                 unicode(OneLogin_Saml2_Constants.NS_SAMLP),
@@ -804,9 +804,9 @@ class OneLogin_Saml2_Utils(object):
                 unicode(OneLogin_Saml2_Constants.NS_SAML)
             )
             xml = xml.toxml()
-            elem = fromstring(str(xml))
+            elem = fromstring(xml.encode('utf-8'))
         elif isinstance(xml, basestring):
-            elem = fromstring(str(xml))
+            elem = fromstring(xml.encode('utf-8'))
         else:
             raise Exception('Error parsing xml string')
 
@@ -849,7 +849,7 @@ class OneLogin_Saml2_Utils(object):
         dsig_ctx.signKey = sign_key
         dsig_ctx.sign(signature)
 
-        newdoc = parseString(etree.tostring(elem))
+        newdoc = parseString(etree.tostring(elem, encoding='unicode').encode('utf-8'))
 
         signature_nodes = newdoc.getElementsByTagName("Signature")
 
@@ -895,7 +895,7 @@ class OneLogin_Saml2_Utils(object):
                 elem = xml
             elif isinstance(xml, Document):
                 xml = xml.toxml()
-                elem = fromstring(str(xml))
+                elem = fromstring(xml.encode('utf-8'))
             elif isinstance(xml, Element):
                 xml.setAttributeNS(
                     unicode(OneLogin_Saml2_Constants.NS_SAMLP),
@@ -908,9 +908,9 @@ class OneLogin_Saml2_Utils(object):
                     unicode(OneLogin_Saml2_Constants.NS_SAML)
                 )
                 xml = xml.toxml()
-                elem = fromstring(str(xml))
+                elem = fromstring(xml.encode('utf-8'))
             elif isinstance(xml, basestring):
-                elem = fromstring(str(xml))
+                elem = fromstring(xml.encode('utf-8'))
             else:
                 raise Exception('Error parsing xml string')
 
@@ -963,7 +963,7 @@ class OneLogin_Saml2_Utils(object):
                 elem = xml
             elif isinstance(xml, Document):
                 xml = xml.toxml()
-                elem = fromstring(str(xml))
+                elem = fromstring(xml.encode('utf-8'))
             elif isinstance(xml, Element):
                 xml.setAttributeNS(
                     unicode(OneLogin_Saml2_Constants.NS_MD),
@@ -971,9 +971,9 @@ class OneLogin_Saml2_Utils(object):
                     unicode(OneLogin_Saml2_Constants.NS_MD)
                 )
                 xml = xml.toxml()
-                elem = fromstring(str(xml))
+                elem = fromstring(xml.encode('utf-8'))
             elif isinstance(xml, basestring):
-                elem = fromstring(str(xml))
+                elem = fromstring(xml.encode('utf-8'))
             else:
                 raise Exception('Error parsing xml string')
 

--- a/tests/settings/settings6.json
+++ b/tests/settings/settings6.json
@@ -1,0 +1,47 @@
+{
+    "strict": false,
+    "debug": false,
+    "custom_base_path": "../../../tests/data/customPath/",
+    "sp": {
+        "entityId": "http://stuff.com/endpoints/metadata.php",
+        "assertionConsumerService": {
+            "url": "http://stuff.com/endpoints/endpoints/acs.php"
+        },
+        "singleLogoutService": {
+            "url": "http://stuff.com/endpoints/endpoints/sls.php"
+        },
+        "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+    },
+    "idp": {
+        "entityId": "http://idp.example.com/",
+        "singleSignOnService": {
+            "url": "http://idp.example.com/SSOService.php"
+        },
+        "singleLogoutService": {
+            "url": "http://idp.example.com/SingleLogoutService.php"
+        },
+        "x509cert": "MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo"
+    },
+    "security": {
+        "authnRequestsSigned": false,
+        "wantAssertionsSigned": false,
+        "signMetadata": false
+    },
+    "contactPerson": {
+        "technical": {
+            "givenName": "Téçhnïçäl Nämé",
+            "emailAddress": "technical@example.com"
+        },
+        "support": {
+            "givenName": "Süppört Nämé",
+            "emailAddress": "support@example.com"
+        }
+    },
+    "organization": {
+        "en-US": {
+            "name": "sp_test",
+            "displayname": "Sérvïçé prövïdér",
+            "url": "http://sp.example.com"
+        }
+    }
+}

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -22,8 +22,8 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
     data_path = join(dirname(dirname(dirname(dirname(__file__)))), 'data')
     settings_path = join(dirname(dirname(dirname(dirname(__file__)))), 'settings')
 
-    def loadSettingsJSON(self):
-        filename = join(self.settings_path, 'settings1.json')
+    def loadSettingsJSON(self, name='settings1.json'):
+        filename = join(self.settings_path, name)
         if exists(filename):
             stream = open(filename, 'r')
             settings = json.load(stream)
@@ -563,6 +563,20 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         self.assertIn(sso_url, target_url)
         self.assertIn('SAMLRequest', parsed_query)
         self.assertIn('RelayState', parsed_query)
+        hostname = OneLogin_Saml2_Utils.get_self_host(request_data)
+        self.assertIn(u'http://%s/index.html' % hostname, parsed_query['RelayState'])
+
+    def testLoginWithUnicodeSettings(self):
+        """
+        Tests the login method of the OneLogin_Saml2_Auth class
+        Case Login with unicode settings. An AuthnRequest is built an redirect executed
+        """
+        settings_info = self.loadSettingsJSON('settings6.json')
+        request_data = self.get_request()
+        auth = OneLogin_Saml2_Auth(request_data, old_settings=settings_info)
+
+        target_url = auth.login()
+        parsed_query = parse_qs(urlparse(target_url)[4])
         hostname = OneLogin_Saml2_Utils.get_self_host(request_data)
         self.assertIn(u'http://%s/index.html' % hostname, parsed_query['RelayState'])
 

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -18,8 +18,8 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
     data_path = join(dirname(dirname(dirname(dirname(__file__)))), 'data')
     settings_path = join(dirname(dirname(dirname(dirname(__file__)))), 'settings')
 
-    def loadSettingsJSON(self):
-        filename = join(self.settings_path, 'settings1.json')
+    def loadSettingsJSON(self, name='settings1.json'):
+        filename = join(self.settings_path, name)
         if exists(filename):
             stream = open(filename, 'r')
             settings = json.load(stream)
@@ -396,6 +396,20 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertIn('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', metadata)
         self.assertIn('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', metadata)
         self.assertIn('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', metadata)
+
+    def testGetUnicodeSPMetadata(self):
+        """
+        Tests the getSPMetadata method of the OneLogin_Saml2_Settings
+        Case unicode metadata
+        """
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON('settings6.json'))
+        metadata = settings.get_sp_metadata()
+
+        self.assertIn('<md:SPSSODescriptor', metadata)
+        self.assertIn('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', metadata)
+        self.assertIn(u'<md:OrganizationDisplayName xml:lang="en-US">Sérvïçé prövïdér</md:OrganizationDisplayName>', metadata)
+        self.assertIn(u'<md:GivenName>Téçhnïçäl Nämé</md:GivenName>', metadata)
+        self.assertIn(u'<md:GivenName>Süppört Nämé</md:GivenName>', metadata)
 
     def testGetSPMetadataSigned(self):
         """

--- a/tests/src/OneLogin/saml2_tests/utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/utils_test.py
@@ -39,6 +39,18 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         f.close()
         return content
 
+    def testDeflateBase64Roundtrip(self):
+        """
+        Tests deflate_and_base64_encode and decode_base64_and_inflate methods of OneLogin_Saml2_Utils
+        """
+        body = 'Some random string.'
+        encoded = OneLogin_Saml2_Utils.deflate_and_base64_encode(body)
+        self.assertEqual(OneLogin_Saml2_Utils.decode_base64_and_inflate(encoded), body)
+
+        unicode_body = u'Sömé rändöm nön-äsçïï strïng.'
+        unicode_encoded = OneLogin_Saml2_Utils.deflate_and_base64_encode(unicode_body)
+        self.assertEqual(OneLogin_Saml2_Utils.decode_base64_and_inflate(unicode_encoded), unicode_body)
+
     def testValidateXML(self):
         """
         Tests the validate_xml method of the OneLogin_Saml2_Utils


### PR DESCRIPTION
This patch adds support for using unicode strings that contain non-ascii characters in settings.

Trying to use non-ascii characters for contact person's given name for example, would fail with unicode encode errors in various places.

The most common settings that may contain non-ascii characters are:

```python
{
  ...
  "contactPerson": {
    "technical": {
      "givenName": "uTéçhnïçäl Nämé",
      ...
    },
    "support": {
      "givenName": u"Süppört Nämé",
      ...
    }
  },

  "organization": {
    "en-US": {
      "displayName": u"Sérvïçé prövïdér",
      ...
    }
  },
  ...
}
```