### PR TITLE
Checking the status of response before assertion count

### DIFF
--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -84,15 +84,15 @@ class OneLogin_Saml2_Response(object):
                     OneLogin_Saml2_ValidationError.MISSING_ID
                 )
 
+            # Checks that the response has the SUCCESS status
+            self.check_status()
+
             # Checks that the response only has one assertion
             if not self.validate_num_assertions():
                 raise OneLogin_Saml2_ValidationError(
                     'SAML Response must contain 1 assertion',
                     OneLogin_Saml2_ValidationError.WRONG_NUMBER_OF_ASSERTIONS
                 )
-
-            # Checks that the response has the SUCCESS status
-            self.check_status()
 
             idp_data = self.__settings.get_idp_data()
             idp_entity_id = idp_data.get('entityId', '')

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1391,6 +1391,17 @@ bP0z0zvDEQnnt/VUWFEBLSJq4Z4Nre8LFmS2
             }))
 
 
+    def testStatusCheckBeforeAssertionCheck(self):
+        """
+        Tests the status of a response is checked before the assertion count. As failed statuses will have no assertions
+        """
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+        xml_2 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'status_code_responder.xml.base64'))
+        response_2 = OneLogin_Saml2_Response(settings, xml_2)
+        with self.assertRaisesRegexp(OneLogin_Saml2_ValidationError, 'The status code of the Response was not Success, was Responder'):
+            response_2.is_valid(self.get_request_data(), raise_exceptions=True)
+
+
 if __name__ == '__main__':
     if is_running_under_teamcity():
         runner = TeamcityTestRunner()

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1396,10 +1396,10 @@ bP0z0zvDEQnnt/VUWFEBLSJq4Z4Nre8LFmS2
         Tests the status of a response is checked before the assertion count. As failed statuses will have no assertions
         """
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
-        xml_2 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'status_code_responder.xml.base64'))
-        response_2 = OneLogin_Saml2_Response(settings, xml_2)
+        xml = self.file_contents(join(self.data_path, 'responses', 'invalids', 'status_code_responder.xml.base64'))
+        response = OneLogin_Saml2_Response(settings, xml)
         with self.assertRaisesRegexp(OneLogin_Saml2_ValidationError, 'The status code of the Response was not Success, was Responder'):
-            response_2.is_valid(self.get_request_data(), raise_exceptions=True)
+            response.is_valid(self.get_request_data(), raise_exceptions=True)
 
 
 if __name__ == '__main__':

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1390,7 +1390,6 @@ bP0z0zvDEQnnt/VUWFEBLSJq4Z4Nre8LFmS2
                 'script_name': 'newonelogin/demo1/index.php?acs'
             }))
 
-
     def testStatusCheckBeforeAssertionCheck(self):
         """
         Tests the status of a response is checked before the assertion count. As failed statuses will have no assertions


### PR DESCRIPTION
Failed Responses don't have assertions and the error hides that the status is not success