### PR TITLE
Upgrade to version 1.3.3 of dm.xmlsec.binding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'dm.xmlsec.binding==1.3.2',
+        'dm.xmlsec.binding==1.3.3',
         'isodate>=0.5.0',
         'defusedxml==0.4.1',
     ],


### PR DESCRIPTION
For me this solved an issue I had on CentOS, where importing `dm.xmlsec.binding` would create a segmenation fault.

I suppose it is the same issue discuted here : https://github.com/onelogin/python-saml/issues/30