### PR TITLE
Fix wrong requestedAttributes nameFormat

### DIFF
--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -91,7 +91,7 @@ class OneLogin_Saml2_Metadata(object):
                 if 'nameFormat' in req_attribs.keys() and req_attribs['nameFormat']:
                     req_attr_nameformat_str = " NameFormat=\"%s\"" % req_attribs['nameFormat']
                 if 'friendlyName' in req_attribs.keys() and req_attribs['friendlyName']:
-                    req_attr_nameformat_str = " FriendlyName=\"%s\"" % req_attribs['friendlyName']
+                    req_attr_friendlyname_str = " FriendlyName=\"%s\"" % req_attribs['friendlyName']
                 if 'isRequired' in req_attribs.keys() and req_attribs['isRequired']:
                     req_attr_isrequired_str = " isRequired=\"%s\"" % 'true' if req_attribs['isRequired'] else 'false'
 


### PR DESCRIPTION
Because of a typo when generating the service metadata, it was not possible to set the `nameFormat` for a `requestedAttributes` entry.