### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python3: [python3-saml](https://github.com/onelogin/python3-saml).
 
 #### Warning ####
 
-Update python-saml to 2.2.3, this version replaces some etree.tostring calls, that were introduced recfently,  by the sanitized call provided by defusedxml
+Update python-saml to 2.2.3, this version replaces some etree.tostring calls, that were introduced recently,  by the sanitized call provided by defusedxml
 
 Update python-saml to 2.2.0, this version includes a security patch that contains extra validations that will prevent signature wrapping attacks. [CVE-2016-1000252](https://github.com/distributedweaknessfiling/DWF-Database-Artifacts/blob/master/DWF/2016/1000252/CVE-2016-1000252.json)
 


### PR DESCRIPTION
Just found this small typo while comparing `python3-saml` vs `python-saml` projects.

Btw thanks for the work ;)