### PR TITLE
Allow empty nameid if setting wantNameId is false

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # python-saml changelog
 ### 2.2.4 (unreleased)
 * Get NameID when element decrypted twice
+* Allow empty NameID if setting wantNameId is false
 
 ### 2.2.3 (Jun 15, 2017)
 * Replace some etree.tostring calls, that were introduced recfently,  by the sanitized call provided by defusedxml

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -416,26 +416,28 @@ class OneLogin_Saml2_Response(object):
             nameid_nodes = self.__query_assertion('/saml:Subject/saml:NameID')
             if nameid_nodes:
                 nameid = nameid_nodes[0]
-        if nameid is None:
-            security = self.__settings.get_security_data()
 
-            if security.get('wantNameId', True):
+        is_strict = self.__settings.is_strict()
+        want_nameid = self.__settings.get_security_data().get('wantNameId', True)
+
+        if nameid is None:
+            if want_nameid:
                 raise OneLogin_Saml2_ValidationError(
                     'NameID not found in the assertion of the Response',
                     OneLogin_Saml2_ValidationError.NO_NAMEID
                 )
-        else:
-            if self.__settings.is_strict() and not nameid.text:
+        elif not nameid.text:
+            if is_strict and want_nameid:
                 raise OneLogin_Saml2_ValidationError(
                     'An empty NameID value found',
                     OneLogin_Saml2_ValidationError.EMPTY_NAMEID
                 )
-
+        else:
             nameid_data = {'Value': nameid.text}
             for attr in ['Format', 'SPNameQualifier', 'NameQualifier']:
                 value = nameid.get(attr, None)
                 if value:
-                    if self.__settings.is_strict() and attr == 'SPNameQualifier':
+                    if is_strict and attr == 'SPNameQualifier':
                         sp_data = self.__settings.get_sp_data()
                         sp_entity_id = sp_data.get('entityId', '')
                         if sp_entity_id != value:

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -135,6 +135,12 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         with self.assertRaisesRegexp(OneLogin_Saml2_ValidationError, 'An empty NameID value found'):
             response_9.get_nameid()
 
+        json_settings['security']['wantNameId'] = False
+        settings = OneLogin_Saml2_Settings(json_settings)
+
+        nameid_9 = response_9.get_nameid()
+        self.assertEqual(None, nameid_9)
+
     def testReturnNameIdFormat(self):
         """
         Tests the get_nameid_format method of the OneLogin_Saml2_Response
@@ -192,6 +198,12 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         response_9 = OneLogin_Saml2_Response(settings, xml_6)
         with self.assertRaisesRegexp(OneLogin_Saml2_ValidationError, 'An empty NameID value found'):
             response_9.get_nameid_format()
+
+        json_settings['security']['wantNameId'] = False
+        settings = OneLogin_Saml2_Settings(json_settings)
+
+        nameid_9 = response_9.get_nameid_format()
+        self.assertEqual(None, nameid_9)
 
     def testGetNameIdData(self):
         """
@@ -268,6 +280,12 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         response_9 = OneLogin_Saml2_Response(settings, xml_6)
         with self.assertRaisesRegexp(OneLogin_Saml2_ValidationError, 'An empty NameID value found'):
             response_9.get_nameid_data()
+
+        json_settings['security']['wantNameId'] = False
+        settings = OneLogin_Saml2_Settings(json_settings)
+
+        nameid_data_9 = response_9.get_nameid_data()
+        self.assertEqual({}, nameid_data_9)
 
     def testCheckStatus(self):
         """


### PR DESCRIPTION
We encounter a case were the IdP send us back a response with an empty NameID node. For now and we have to validate its response with the setting `strict` set to `false`.

In this PR we would to allow this case more explicitly and more in a more secure way by using the setting `wantNameId`.