### PR TITLE
[Add] Limited support for <Scoping> in SAML2

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ This is the settings.json file:
         // represent the requested subject.
         // Take a look on src/onelogin/saml2/constants.py to see the NameIdFormat that are supported.
         "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+        // List of IdPs (entityIds) allowed to authenticate the request (SAML2 Scoping)
+        "scopingIdpList": ["https://<idp_domain>"],
         // Usually x509cert and privateKey of the SP are provided by files placed at
         // the certs folder. But we can also provide them with the following parameters
         "x509cert": "",

--- a/src/onelogin/saml2/authn_request.py
+++ b/src/onelogin/saml2/authn_request.py
@@ -100,6 +100,19 @@ class OneLogin_Saml2_Authn_Request(object):
         if 'attributeConsumingService' in sp_data and sp_data['attributeConsumingService']:
             attr_consuming_service_str = 'AttributeConsumingServiceIndex="1"'
 
+        scoping_str = ''
+        if 'scopingIdpList' in sp_data:
+            scoping_idp_str = ''
+            for idp in sp_data['scopingIdpList']:
+                scoping_idp_str += '            <samlp:IDPEntry ProviderID="%s" />' % idp
+
+            scoping_str = '''\
+    <samlp:Scoping>
+        <samlp:IDPList>
+            %s
+        </samlp:IDPList>
+    </samlp:Scoping>''' % scoping_idp_str
+
         request = """<samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -110,7 +123,7 @@ class OneLogin_Saml2_Authn_Request(object):
     ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
     AssertionConsumerServiceURL="%(assertion_url)s"
     %(attr_consuming_service_str)s>
-    <saml:Issuer>%(entity_id)s</saml:Issuer>%(nameid_policy_str)s%(requested_authn_context_str)s
+    <saml:Issuer>%(entity_id)s</saml:Issuer>%(nameid_policy_str)s%(requested_authn_context_str)s%(scoping_str)s
 </samlp:AuthnRequest>""" % \
             {
                 'id': uid,
@@ -123,7 +136,8 @@ class OneLogin_Saml2_Authn_Request(object):
                 'entity_id': sp_data['entityId'],
                 'nameid_policy_str': nameid_policy_str,
                 'requested_authn_context_str': requested_authn_context_str,
-                'attr_consuming_service_str': attr_consuming_service_str
+                'attr_consuming_service_str': attr_consuming_service_str,
+                'scoping_str': scoping_str
             }
 
         self.__authn_request = request


### PR DESCRIPTION
The `<Scoping>`-tag in SAML2 allows service providers (SPs) to specify which
identity providers (IDPs) are allowed/expected to authenticate the
login request.

See: http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf (page 51)