### PR TITLE
[Add] Allow custom filename for "settings.json"

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,12 @@ auth = OneLogin_Saml2_Auth(req, custom_base_path=custom_folder)
 # or
 settings = OneLogin_Saml2_Settings(custom_base_path=custom_folder)
 
+# Initializes toolkit with the custom settings file "my_settings.json" and the standard "advanced_settings.json".
+custom_folder = '/var/www/django-project'
+auth = OneLogin_Saml2_Auth(req, 'my_settings.json', custom_base_path=custom_folder)
+# or
+settings = OneLogin_Saml2_Settings('my_settings.json', custom_base_path=custom_folder)
+
 # Initializes toolkit with the dict provided.
 auth = OneLogin_Saml2_Auth(req, settings_data)
 # or

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -49,7 +49,6 @@ class OneLogin_Saml2_Auth(object):
         :type custom_base_path: string
         """
         self.__request_data = request_data
-        self.__settings = OneLogin_Saml2_Settings(old_settings, custom_base_path)
         self.__attributes = []
         self.__nameid = None
         self.__nameid_format = None
@@ -64,6 +63,11 @@ class OneLogin_Saml2_Auth(object):
         self.__last_assertion_not_on_or_after = None
         self.__last_request = None
         self.__last_response = None
+
+        if isinstance(old_settings, OneLogin_Saml2_Settings):
+            self.__settings = old_settings
+        else:
+            self.__settings = OneLogin_Saml2_Settings(old_settings, custom_base_path)
 
     def get_settings(self):
         """

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -96,6 +96,18 @@ class OneLogin_Saml2_Settings(object):
                     ','.join(self.__errors)
                 )
             self.__add_default_values()
+        elif isinstance(settings, str):
+            try:
+                valid = self.__load_settings_from_file(settings)
+            except Exception as e:
+                raise e
+            if not valid:
+                raise OneLogin_Saml2_Error(
+                    'Invalid dict settings at the file: %s',
+                    OneLogin_Saml2_Error.SETTINGS_INVALID,
+                    ','.join(self.__errors)
+                )
+            self.__add_default_values()
         elif isinstance(settings, dict):
             if not self.__load_settings_from_dict(settings):
                 raise OneLogin_Saml2_Error(
@@ -217,31 +229,31 @@ class OneLogin_Saml2_Settings(object):
         self.__errors = errors
         return False
 
-    def __load_settings_from_file(self):
+    def __load_settings_from_file(self, filename='settings.json'):
         """
         Loads settings info from the settings json file
 
         :returns: True if the settings info is valid
         :rtype: boolean
         """
-        filename = self.get_base_path() + 'settings.json'
+        filepath = self.get_base_path() + filename
 
-        if not exists(filename):
+        if not exists(filepath):
             raise OneLogin_Saml2_Error(
                 'Settings file not found: %s',
                 OneLogin_Saml2_Error.SETTINGS_FILE_NOT_FOUND,
-                filename
+                filepath
             )
 
         # In the php toolkit instead of being a json file it is a php file and
         # it is directly included
-        json_data = open(filename, 'r')
+        json_data = open(filepath, 'r')
         settings = json.load(json_data)
         json_data.close()
 
-        advanced_filename = self.get_base_path() + 'advanced_settings.json'
-        if exists(advanced_filename):
-            json_data = open(advanced_filename, 'r')
+        advanced_filepath = self.get_base_path() + 'advanced_settings.json'
+        if exists(advanced_filepath):
+            json_data = open(advanced_filepath, 'r')
             settings.update(json.load(json_data))  # Merge settings
             json_data.close()
 

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -60,6 +60,20 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         auth_settings = auth.get_settings()
         self.assertEqual(settings.get_sp_data(), auth_settings.get_sp_data())
 
+    def testGetSettingsCustom(self):
+        """
+        Tests the get_settings method of the OneLogin_Saml2_Auth class
+        Build a OneLogin_Saml2_Settings object with a setting array
+        and compare the value returned from the method of the
+        auth object
+        """
+        path = join(dirname(__file__), '..', '..', '..', 'settings')
+        settings_direct = OneLogin_Saml2_Settings('settings1.json', custom_base_path=path)
+        auth = OneLogin_Saml2_Auth(self.get_request(), 'settings1.json', custom_base_path=path)
+
+        settings_auth = auth.get_settings()
+        self.assertEqual(settings_direct.get_sp_data(), settings_auth.get_sp_data())
+
     def testGetSSOurl(self):
         """
         Tests the get_sso_url method of the OneLogin_Saml2_Auth class

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -113,6 +113,23 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         settings_3 = OneLogin_Saml2_Settings(custom_base_path=custom_base_path)
         self.assertEqual(len(settings_3.get_errors()), 0)
 
+    def testLoadSettingsFromCustomFile(self):
+        """
+        Tests the OneLogin_Saml2_Settings Constructor.
+        Case load setting from a custom file (other than "settings.json")
+        """
+        custom_base_path = join(dirname(__file__), '..', '..', '..', 'settings')
+        settings_custom = OneLogin_Saml2_Settings('settings1.json', custom_base_path=custom_base_path)
+        self.assertEqual(len(settings_custom.get_errors()), 0)
+
+        f = open(join(custom_base_path, 'settings1.json'))
+        d_json = json.load(f)
+        f.close()
+
+        settings_manual = OneLogin_Saml2_Settings(d_json, custom_base_path=custom_base_path)
+
+        self.assertEqual(settings_custom.get_sp_data(), settings_manual.get_sp_data())
+
     def testGetCertPath(self):
         """
         Tests getCertPath method of the OneLogin_Saml2_Settings


### PR DESCRIPTION
This commit allows `OneLogin_Saml2_Settings` and `OneLogin_Saml2_Auth` to read in settings from a specified file instead of the default "settings.json", making it easier to change between configurations (e.g. for staging versus production environments).