### PR TITLE
Travis CI: Add Python 3.6 to testing in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
 python:
   - '2.7.6'
-# - '2.7.12'  
+# - '2.7.12'
+  - '2.7'
+  - '3.6'
+matrix:
+  allow_failures:
+    - python: '3.6'
 
 install:
   - sudo apt-get update -qq


### PR DESCRIPTION
Allows us to see where we are on Python 3 compatibility.