### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -8,6 +8,7 @@ MIT License
 Logout Request class of OneLogin's Python Toolkit.
 
 """
+from __future__ import print_function
 
 from zlib import decompress
 from base64 import b64encode, b64decode
@@ -425,7 +426,7 @@ class OneLogin_Saml2_Logout_Request(object):
             self.__error = err.__str__()
             debug = self.__settings.is_debug_active()
             if debug:
-                print err.__str__()
+                print(err.__str__())
             if raise_exceptions:
                 raise err
             return False

--- a/src/onelogin/saml2/logout_response.py
+++ b/src/onelogin/saml2/logout_response.py
@@ -8,6 +8,7 @@ MIT License
 Logout Response class of OneLogin's Python Toolkit.
 
 """
+from __future__ import print_function
 
 from base64 import b64encode, b64decode
 from defusedxml.lxml import fromstring
@@ -185,7 +186,7 @@ class OneLogin_Saml2_Logout_Response(object):
             self.__error = err.__str__()
             debug = self.__settings.is_debug_active()
             if debug:
-                print err.__str__()
+                print(err.__str__())
             if raise_exceptions:
                 raise err
             return False

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -8,6 +8,7 @@ MIT License
 SAML Response class of OneLogin's Python Toolkit.
 
 """
+from __future__ import print_function
 
 from base64 import b64decode
 from copy import deepcopy
@@ -328,7 +329,7 @@ class OneLogin_Saml2_Response(object):
             self.__error = err.__str__()
             debug = self.__settings.is_debug_active()
             if debug:
-                print err.__str__()
+                print(err.__str__())
             if raise_exceptions:
                 raise err
             return False

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -436,9 +436,9 @@ class OneLogin_Saml2_Settings(object):
                                 errors.append('sp_attributeConsumingService_requestedAttributes_name_not_found')
                             if 'name' in req_attrib and not req_attrib['name'].strip():
                                 errors.append('sp_attributeConsumingService_requestedAttributes_name_invalid')
-                            if 'attributeValue' in req_attrib and type(req_attrib['attributeValue']) != list:
+                            if 'attributeValue' in req_attrib and not isinstance(req_attrib['attributeValue'], list):
                                 errors.append('sp_attributeConsumingService_requestedAttributes_attributeValue_type_invalid')
-                            if 'isRequired' in req_attrib and type(req_attrib['isRequired']) != bool:
+                            if 'isRequired' in req_attrib and not isinstance(req_attrib['isRequired'], bool):
                                 errors.append('sp_attributeConsumingService_requestedAttributes_isRequired_type_invalid')
 
                     if "serviceDescription" in attributeConsumingService and not isinstance(attributeConsumingService['serviceDescription'], basestring):

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -8,6 +8,7 @@ MIT License
 Auxiliary class of OneLogin's Python Toolkit.
 
 """
+from __future__ import print_function
 
 import base64
 from copy import deepcopy
@@ -75,7 +76,7 @@ def print_xmlsec_errors(filename, line, func, error_object, error_subject, reaso
     if reason != 1:
         info.append("errno=%d" % reason)
     if info:
-        print "%s:%d(%s)" % (filename, line, func), " ".join(info)
+        print("%s:%d(%s)" % (filename, line, func), " ".join(info))
 
 
 class OneLogin_Saml2_Utils(object):


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Also use __isinstance()__ instead of directly comparing types as discussed in PEP8.