### PR TITLE
setup.py - Bump dm.xmlsec.binding requirement to 2.0 for py3 compatability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'dm.xmlsec.binding==1.3.7',
+        'dm.xmlsec.binding==2.0',
         'isodate>=0.5.0',
         'defusedxml>=0.4.1',
     ],


### PR DESCRIPTION
This will allow for python-saml to at least install in a py3 env